### PR TITLE
add grimblast

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,9 @@
     ];
     pkgsFor = nixpkgs.legacyPackages;
   in {
-    overlays.default = _: prev: {};
+    overlays.default = _: prev: {
+      grimblast = prev.callPackage ./grimblast {hyprland = null;};
+    };
 
     packages = genSystems (system: self.overlays.default null pkgsFor.${system});
 

--- a/grimblast/.gitignore
+++ b/grimblast/.gitignore
@@ -1,0 +1,1 @@
+grimblast.1

--- a/grimblast/Makefile
+++ b/grimblast/Makefile
@@ -1,0 +1,12 @@
+PREFIX ?= /usr
+BINDIR ?= $(PREFIX)/bin
+MANDIR ?= $(PREFIX)/share/man
+
+all: grimblast.1
+
+grimblast.1: grimblast.1.scd
+	scdoc < $< > $@
+
+install: grimblast.1 grimblast
+	@install -v -D -m 0644 grimblast.1 --target-directory "$(MANDIR)/man1"
+	@install -v -D -m 0755 grimblast --target-directory "$(BINDIR)"

--- a/grimblast/default.nix
+++ b/grimblast/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  coreutils,
+  scdoc,
+  makeWrapper,
+  wl-clipboard,
+  libnotify,
+  slurp,
+  grim,
+  jq,
+  bash,
+  hyprland ? null,
+}:
+stdenv.mkDerivation rec {
+  pname = "grimblast";
+  version = "0.1";
+  src = ./.;
+
+  buildInputs = [bash scdoc];
+  makeFlags = ["PREFIX=$(out)"];
+  nativeBuildInputs = [makeWrapper];
+
+  postInstall = ''
+    wrapProgram $out/bin/grimblast --prefix PATH ':' \
+      "${lib.makeBinPath ([
+        wl-clipboard
+        coreutils
+        libnotify
+        slurp
+        grim
+        jq
+      ]
+      ++ lib.optional (hyprland != null) hyprland)}"
+  '';
+
+  meta = with lib; {
+    description = "A helper for screenshots within hyprland, based on grimshot";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainer = with maintainers; [misterio77];
+  };
+}

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -1,0 +1,175 @@
+#!/bin/sh
+## Grimblast: a helper for screenshots within hyprland
+## Requirements:
+##  - `grim`: screenshot utility for wayland
+##  - `slurp`: to select an area
+##  - `hyprctl`: to read properties of current window
+##  - `wl-copy`: clipboard utility
+##  - `jq`: json utility to parse hyprctl output
+##  - `notify-send`: to show notifications
+## Those are needed to be installed, if unsure, run `grimblast check`
+##
+## See `man 1 grimblast` or `grimblast usage` for further details.
+
+## Author: Misterio (https://github.com/misterio77)
+
+## This tool is based on grimshot, with swaymsg commands replaced by their
+## hyprctl equivalents.
+## https://github.com/swaywm/sway/blob/master/contrib/grimshot
+
+getTargetDirectory() {
+  test -f "${XDG_CONFIG_HOME:-~/.config}/user-dirs.dirs" && \
+    . "${XDG_CONFIG_HOME:-~/.config}/user-dirs.dirs"
+
+  echo "${XDG_SCREENSHOTS_DIR:-${XDG_PICTURES_DIR:-$HOME}}"
+}
+
+NOTIFY=no
+CURSOR=
+
+while [ $# -gt 0 ]; do
+  key="$1"
+
+  case $key in
+    -n|--notify)
+      NOTIFY=yes
+      shift # past argument
+      ;;
+    -c|--cursor)
+      CURSOR=yes
+      shift # past argument
+      ;;
+    *)    # unknown option
+      break # done with parsing --flags
+      ;;
+  esac
+done
+
+ACTION=${1:-usage}
+SUBJECT=${2:-screen}
+FILE=${3:-$(getTargetDirectory)/$(date -Ins).png}
+
+if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "check" ]; then
+  echo "Usage:"
+  echo "  grimblast [--notify] [--cursor] (copy|save) [active|screen|output|area|window] [FILE|-]"
+  echo "  grimblast check"
+  echo "  grimblast usage"
+  echo ""
+  echo "Commands:"
+  echo "  copy: Copy the screenshot data into the clipboard."
+  echo "  save: Save the screenshot to a regular file or '-' to pipe to STDOUT."
+  echo "  check: Verify if required tools are installed and exit."
+  echo "  usage: Show this message and exit."
+  echo ""
+  echo "Targets:"
+  echo "  active: Currently active window."
+  echo "  screen: All visible outputs."
+  echo "  output: Currently active output."
+  echo "  area: Manually select a region."
+  echo "  window: Manually select a window."
+  exit
+fi
+
+notify() {
+  notify-send -t 3000 -a grimblast "$@"
+}
+notifyOk() {
+  [ "$NOTIFY" = "no" ] && return
+
+  TITLE=${2:-"Screenshot"}
+  MESSAGE=${1:-"OK"}
+  notify "$TITLE" "$MESSAGE"
+}
+notifyError() {
+  if [ $NOTIFY = "yes" ]; then
+    TITLE=${2:-"Screenshot"}
+    MESSAGE=${1:-"Error taking screenshot with grim"}
+    notify -u critical "$TITLE" "$MESSAGE"
+  else
+    echo "$1"
+  fi
+}
+
+die() {
+  MSG=${1:-Bye}
+  notifyError "Error: $MSG"
+  exit 2
+}
+
+check() {
+  COMMAND=$1
+  if command -v "$COMMAND" > /dev/null 2>&1; then
+    RESULT="OK"
+  else
+    RESULT="NOT FOUND"
+  fi
+  echo "   $COMMAND: $RESULT"
+}
+
+takeScreenshot() {
+  FILE=$1
+  GEOM=$2
+  OUTPUT=$3
+  if [ -n "$OUTPUT" ]; then
+    grim ${CURSOR:+-c} -o "$OUTPUT" "$FILE" || die "Unable to invoke grim"
+  elif [ -z "$GEOM" ]; then
+    grim ${CURSOR:+-c} "$FILE" || die "Unable to invoke grim"
+  else
+    grim ${CURSOR:+-c} -g "$GEOM" "$FILE" || die "Unable to invoke grim"
+  fi
+}
+
+if [ "$ACTION" = "check" ] ; then
+  echo "Checking if required tools are installed. If something is missing, install it to your system and make it available in PATH..."
+  check grim
+  check slurp
+  check hyprctl
+  check wl-copy
+  check jq
+  check notify-send
+  exit
+elif [ "$SUBJECT" = "area" ] ; then
+  GEOM=$(slurp -d)
+  # Check if user exited slurp without selecting the area
+  if [ -z "$GEOM" ]; then
+    exit 1
+  fi
+  WHAT="Area"
+elif [ "$SUBJECT" = "active" ] ; then
+  FOCUSED=$(hyprctl activewindow -j)
+  GEOM=$(echo "$FOCUSED" | jq -r '"\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"')
+  APP_ID=$(echo "$FOCUSED" | jq -r '.class')
+  WHAT="$APP_ID window"
+elif [ "$SUBJECT" = "screen" ] ; then
+  GEOM=""
+  WHAT="Screen"
+elif [ "$SUBJECT" = "output" ] ; then
+  GEOM=""
+  OUTPUT=$(hyprctl monitors -j | jq -r '.[] | select(.active == "yes")' | jq -r '.name')
+  WHAT="$OUTPUT"
+elif [ "$SUBJECT" = "window" ] ; then
+  WORKSPACES="$(hyprctl monitors -j | jq -r 'map(.activeWorkspace.id)')"
+  WINDOWS="$(hyprctl clients -j | jq -r --argjson workspaces "$WORKSPACES" 'map(select([.workspace.id] | inside($workspaces)))' )"
+  GEOM=$(echo "$WINDOWS" | jq -r '.[] | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"' | slurp)
+  # Check if user exited slurp without selecting the area
+  if [ -z "$GEOM" ]; then
+   exit 1
+  fi
+  WHAT="Window"
+else
+  die "Unknown subject to take a screen shot from" "$SUBJECT"
+fi
+
+if [ "$ACTION" = "copy" ] ; then
+  takeScreenshot - "$GEOM" "$OUTPUT" | wl-copy --type image/png || die "Clipboard error"
+  notifyOk "$WHAT copied to buffer"
+else
+  if takeScreenshot "$FILE" "$GEOM" "$OUTPUT"; then
+    TITLE="Screenshot of $SUBJECT"
+    MESSAGE=$(basename "$FILE")
+    notifyOk "$MESSAGE" "$TITLE"
+    echo "$FILE"
+  else
+    notifyError "Error taking screenshot with grim"
+  fi
+fi

--- a/grimblast/grimblast.1.scd
+++ b/grimblast/grimblast.1.scd
@@ -1,0 +1,82 @@
+grimblast(1)
+
+# NAME
+
+grimblast - a helper for screenshots within hyprland
+
+# SYNOPSIS
+
+*grimblast* [--notify] [--cursor] (copy|save) [TARGET] [FILE]++
+*grimblast* check++
+*grimblast* usage
+
+# OPTIONS
+
+*--notify*
+	Show notifications to the user that a screenshot has been taken.
+
+*--cursor*
+	Include cursors in the screenshot.
+
+*save*
+	Save the screenshot into a regular file. Grimblast will write image
+	files to *XDG_SCREENSHOTS_DIR* if this is set (or defined
+	in *user-dirs.dir*), or otherwise fall back to *XDG_PICTURES_DIR*.
+	Set FILE to '-' to pipe the output to STDOUT.
+
+*copy*
+	Copy the screenshot data (as image/png) into the clipboard.
+
+# DESCRIPTION
+
+Grimblast is an easy-to-use screenshot utility for hyprland, based on grimshot.
+It provides a convenient interface over grim, slurp and jq, and supports
+storing the screenshot either directly to the clipboard using wl-copy or to a
+file.
+
+# EXAMPLES
+
+An example usage pattern is to add these bindings to your hyprland config:
+
+```
+# Screenshots:
+# Super+P: Current window
+# Super+Shift+p: Select area
+# Super+Alt+p Current output
+# Super+Ctrl+p Select a window
+
+bindsym Mod4+p       exec grimblast save active
+bindsym Mod4+Shift+p exec grimblast save area
+bindsym Mod4+Mod1+p  exec grimblast save output
+bindsym Mod4+Ctrl+p  exec grimblast save window
+```
+
+# TARGETS
+
+grimblast can capture the following named targets:
+
+_active_
+	Captures the currently active window.
+
+_screen_
+	Captures the entire screen. This includes all visible outputs.
+
+_area_
+	Allows manually selecting a rectangular region, and captures that.
+
+_window_
+	Allows manually selecting a single window (by clicking on it), and
+	captures it.
+
+_output_
+	Captures the currently active output.
+
+# OUTPUT
+
+Grimblast will print the filename of the captured screenshot to stdout if called
+with the _save_ subcommand.
+
+# SEE ALSO
+
+*grim*(1)
+*grimshot*(1)


### PR DESCRIPTION
Heyo!

This PR adds grimblast, a screenshot tool based on grimshot.

I've also included a manpage (scdoc format), a Makefile for easily building the docs (and possibly more things such as completions futurely) and installing them to the right places.

There's also a nix derivation for it, that uses the Makefile. The derivation wrapper has hyprland as an input. As we don't want to add hyprland as a flake input here, it defaults to null (which mostly works when hyprctl is on the PATH) when consuming through the flake package/overlay, and can be overridden.

I can write a PKGBUILD too, but I don't plan on maintaining an AUR package.