### PR TITLE
grimblast: add copysave option

### DIFF
--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -49,15 +49,16 @@ ACTION=${1:-usage}
 SUBJECT=${2:-screen}
 FILE=${3:-$(getTargetDirectory)/$(date -Ins).png}
 
-if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "check" ]; then
+if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "copysave" ] && [ "$ACTION" != "check" ]; then
   echo "Usage:"
-  echo "  grimblast [--notify] [--cursor] (copy|save) [active|screen|output|area|window] [FILE|-]"
+  echo "  grimblast [--notify] [--cursor] (copy|save|copysave) [active|screen|output|area|window] [FILE|-]"
   echo "  grimblast check"
   echo "  grimblast usage"
   echo ""
   echo "Commands:"
   echo "  copy: Copy the screenshot data into the clipboard."
   echo "  save: Save the screenshot to a regular file or '-' to pipe to STDOUT."
+  echo "  copysave: Combine the previous 2 options."
   echo "  check: Verify if required tools are installed and exit."
   echo "  usage: Show this message and exit."
   echo ""
@@ -173,11 +174,19 @@ fi
 if [ "$ACTION" = "copy" ] ; then
   takeScreenshot - "$GEOM" "$OUTPUT" | wl-copy --type image/png || die "Clipboard error"
   notifyOk "$WHAT copied to buffer"
-else
+elif [ "$ACTION" = "save" ] ; then
   if takeScreenshot "$FILE" "$GEOM" "$OUTPUT"; then
     TITLE="Screenshot of $SUBJECT"
     MESSAGE=$(basename "$FILE")
     notifyOk "$MESSAGE" "$TITLE" -i "$FILE"
+    echo "$FILE"
+  else
+    notifyError "Error taking screenshot with grim"
+  fi
+else
+  if [ "$ACTION" = "copysave" ] ; then
+    takeScreenshot - "$GEOM" "$OUTPUT" | tee "$FILE" | wl-copy --type image/png || die "Clipboard error"
+    notifyOk "$WHAT copied to buffer and saved to $FILE"
     echo "$FILE"
   else
     notifyError "Error taking screenshot with grim"


### PR DESCRIPTION
Fixes #3

This is the simplest approach I could think of. Specifying both `copy` and `save` in one command would've required a better parsing mechanism that I honestly don't know how to implement in bash.

Feel free to suggest a better approach.