### PR TITLE
grimblast/nix: fix meta.maintainers key

### DIFF
--- a/grimblast/default.nix
+++ b/grimblast/default.nix
@@ -38,6 +38,6 @@ stdenvNoCC.mkDerivation {
     description = "A helper for screenshots within hyprland, based on grimshot";
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainer = with maintainers; [misterio77];
+    maintainers = with maintainers; [misterio77];
   };
 }


### PR DESCRIPTION
Bumping nixpkgs caused an error related to grimblasts' meta:
```
->> home-manager --flake . switch 
error: Package ‘grimblast-0.1’ in /nix/store/331y7r22jc0pdlki8axnzgby1mipdc4b-source/grimblast/default.nix:38 has an invalid meta attrset:
       	- key 'meta.maintainer' is unrecognized; expected one of:
       	     ['available', 'badPlatforms', 'branch', 'broken', 'changelog', 'description', 'downloadPage', 'executables', 'homepage', 'hydraPlatforms', 'insecure', 'isBuildPythonPackage', 'isFcitxEngine', 'isGutenprint', 'isIbusEngine', 'knownVulnerabilities', 'license', 'longDescription', 'mainProgram', 'maintainers', 'maxSilent', 'name', 'outputsToInstall', 'platforms', 'position', 'priority', 'schedulingPriority', 'sourceProvenance', 'tag', 'tests', 'timeout', 'unfree', 'unsupported', 'version'], refusing to evaluate.
(use '--show-trace' to show detailed location information)
```

I think I might not have noticed `meta.maintainer` was deprecated, and nixpkgs seemingly removed it now. Fixed it to `meta.maintainers`.