### PR TITLE
grimblast: fix parameter quoting in notifyOk

### DIFF
--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -80,7 +80,7 @@ notifyOk() {
   TITLE=${2:-"Screenshot"}
   MESSAGE=${1:-"OK"}
   REST=${@: 3}
-  notify "$TITLE" "$MESSAGE" "$REST"
+  notify "$TITLE" "$MESSAGE" $REST
 }
 notifyError() {
   if [ $NOTIFY = "yes" ]; then


### PR DESCRIPTION
quoting the $REST argument was causing notify to treat the arguments as a single token instead of the multiple tokens required for the notify icon to be set correctly.

