### PR TITLE
Fixed GRIMBLAST Variable check and fix formatting

### DIFF
--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -18,45 +18,45 @@
 ## https://github.com/swaywm/sway/blob/master/contrib/grimshot
 
 getTargetDirectory() {
-  test -f "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs" && \
-    . "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs"
+	test -f "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs" &&
+		. "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs"
 
-  echo "${XDG_SCREENSHOTS_DIR:-${XDG_PICTURES_DIR:-$HOME}}"
+	echo "${XDG_SCREENSHOTS_DIR:-${XDG_PICTURES_DIR:-$HOME}}"
 }
 
-tmp_editor_directory () {
-  echo "/tmp"
+tmp_editor_directory() {
+	echo "/tmp"
 }
 
-#Detect if $GRIMPBLAST_EDITOR env exist
-env_editor_confirm () {
-  if [ $(printenv GRIMBLAST_EDITOR; echo $?) -eq 0 ]; then
-    echo "GRIMBLAST_EDITOR is set. Continuing..."
-  else
-    echo "GRIMBLAST_EDITOR is not set. Defaulting to gimp"
-    GRIMBLAST_EDITOR=gimp
-  fi
+#Detect if $GRIMBLAST_EDITOR env exist
+env_editor_confirm() {
+	if [ -n "$GRIMBLAST_EDITOR" ]; then
+		echo "GRIMBLAST_EDITOR is set. Continuing..."
+	else
+		echo "GRIMBLAST_EDITOR is not set. Defaulting to gimp"
+		GRIMBLAST_EDITOR=gimp
+	fi
 }
 
 NOTIFY=no
 CURSOR=
 
 while [ $# -gt 0 ]; do
-  key="$1"
+	key="$1"
 
-  case $key in
-    -n|--notify)
-      NOTIFY=yes
-      shift # past argument
-      ;;
-    -c|--cursor)
-      CURSOR=yes
-      shift # past argument
-      ;;
-    *)    # unknown option
-      break # done with parsing --flags
-      ;;
-  esac
+	case $key in
+	-n | --notify)
+		NOTIFY=yes
+		shift # past argument
+		;;
+	-c | --cursor)
+		CURSOR=yes
+		shift # past argument
+		;;
+	*)     # unknown option
+		break # done with parsing --flags
+		;;
+	esac
 done
 
 ACTION=${1:-usage}
@@ -65,142 +65,142 @@ FILE=${3:-$(getTargetDirectory)/$(date -Ins).png}
 FILE_EDITOR=${3:-$(tmp_editor_directory)/$(date -Ins).png}
 
 if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "edit" ] && [ "$ACTION" != "copysave" ] && [ "$ACTION" != "check" ]; then
-  echo "Usage:"
-  echo "  grimblast [--notify] [--cursor] (copy|save|copysave|edit) [active|screen|output|area] [FILE|-]"
-  echo "  grimblast check"
-  echo "  grimblast usage"
-  echo ""
-  echo "Commands:"
-  echo "  copy: Copy the screenshot data into the clipboard."
-  echo "  save: Save the screenshot to a regular file or '-' to pipe to STDOUT."
-  echo "  copysave: Combine the previous 2 options."
-  echo "  edit: Open screenshot in the image editor of your choice (default is gimp). See man page for info."
-  echo "  check: Verify if required tools are installed and exit."
-  echo "  usage: Show this message and exit."
-  echo ""
-  echo "Targets:"
-  echo "  active: Currently active window."
-  echo "  screen: All visible outputs."
-  echo "  output: Currently active output."
-  echo "  area: Manually select a region or window."
-  exit
+	echo "Usage:"
+	echo "  grimblast [--notify] [--cursor] (copy|save|copysave|edit) [active|screen|output|area] [FILE|-]"
+	echo "  grimblast check"
+	echo "  grimblast usage"
+	echo ""
+	echo "Commands:"
+	echo "  copy: Copy the screenshot data into the clipboard."
+	echo "  save: Save the screenshot to a regular file or '-' to pipe to STDOUT."
+	echo "  copysave: Combine the previous 2 options."
+	echo "  edit: Open screenshot in the image editor of your choice (default is gimp). See man page for info."
+	echo "  check: Verify if required tools are installed and exit."
+	echo "  usage: Show this message and exit."
+	echo ""
+	echo "Targets:"
+	echo "  active: Currently active window."
+	echo "  screen: All visible outputs."
+	echo "  output: Currently active output."
+	echo "  area: Manually select a region or window."
+	exit
 fi
 
 notify() {
-  notify-send -t 3000 -a grimblast "$@"
+	notify-send -t 3000 -a grimblast "$@"
 }
 notifyOk() {
-  [ "$NOTIFY" = "no" ] && return
+	[ "$NOTIFY" = "no" ] && return
 
-  TITLE=${2:-"Screenshot"}
-  MESSAGE=${1:-"OK"}
-  REST=${@: 3}
-  notify "$TITLE" "$MESSAGE" $REST
+	TITLE=${2:-"Screenshot"}
+	MESSAGE=${1:-"OK"}
+	REST=${@:3}
+	notify "$TITLE" "$MESSAGE" $REST
 }
 notifyError() {
-  if [ $NOTIFY = "yes" ]; then
-    TITLE=${2:-"Screenshot"}
-    MESSAGE=${1:-"Error taking screenshot with grim"}
-    notify -u critical "$TITLE" "$MESSAGE"
-  else
-    echo "$1"
-  fi
+	if [ $NOTIFY = "yes" ]; then
+		TITLE=${2:-"Screenshot"}
+		MESSAGE=${1:-"Error taking screenshot with grim"}
+		notify -u critical "$TITLE" "$MESSAGE"
+	else
+		echo "$1"
+	fi
 }
 
 die() {
-  MSG=${1:-Bye}
-  notifyError "Error: $MSG"
-  exit 2
+	MSG=${1:-Bye}
+	notifyError "Error: $MSG"
+	exit 2
 }
 
 check() {
-  COMMAND=$1
-  if command -v "$COMMAND" > /dev/null 2>&1; then
-    RESULT="OK"
-  else
-    RESULT="NOT FOUND"
-  fi
-  echo "   $COMMAND: $RESULT"
+	COMMAND=$1
+	if command -v "$COMMAND" >/dev/null 2>&1; then
+		RESULT="OK"
+	else
+		RESULT="NOT FOUND"
+	fi
+	echo "   $COMMAND: $RESULT"
 }
 
 takeScreenshot() {
-  FILE=$1
-  GEOM=$2
-  OUTPUT=$3
-  if [ -n "$OUTPUT" ]; then
-    grim ${CURSOR:+-c} -o "$OUTPUT" "$FILE" || die "Unable to invoke grim"
-  elif [ -z "$GEOM" ]; then
-    grim ${CURSOR:+-c} "$FILE" || die "Unable to invoke grim"
-  else
-    grim ${CURSOR:+-c} -g "$GEOM" "$FILE" || die "Unable to invoke grim"
-  fi
+	FILE=$1
+	GEOM=$2
+	OUTPUT=$3
+	if [ -n "$OUTPUT" ]; then
+		grim ${CURSOR:+-c} -o "$OUTPUT" "$FILE" || die "Unable to invoke grim"
+	elif [ -z "$GEOM" ]; then
+		grim ${CURSOR:+-c} "$FILE" || die "Unable to invoke grim"
+	else
+		grim ${CURSOR:+-c} -g "$GEOM" "$FILE" || die "Unable to invoke grim"
+	fi
 }
 
-if [ "$ACTION" = "check" ] ; then
-  echo "Checking if required tools are installed. If something is missing, install it to your system and make it available in PATH..."
-  check grim
-  check slurp
-  check hyprctl
-  check wl-copy
-  check jq
-  check notify-send
-  exit
-elif [ "$SUBJECT" = "active" ] ; then
-  FOCUSED=$(hyprctl activewindow -j)
-  GEOM=$(echo "$FOCUSED" | jq -r '"\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"')
-  APP_ID=$(echo "$FOCUSED" | jq -r '.class')
-  WHAT="$APP_ID window"
-elif [ "$SUBJECT" = "screen" ] ; then
-  GEOM=""
-  WHAT="Screen"
-elif [ "$SUBJECT" = "output" ] ; then
-  GEOM=""
-  OUTPUT=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true)' | jq -r '.name')
-  WHAT="$OUTPUT"
-elif [ "$SUBJECT" = "area" ] ; then
-  WORKSPACES="$(hyprctl monitors -j | jq -r 'map(.activeWorkspace.id)')"
-  WINDOWS="$(hyprctl clients -j | jq -r --argjson workspaces "$WORKSPACES" 'map(select([.workspace.id] | inside($workspaces)))' )"
-  GEOM=$(echo "$WINDOWS" | jq -r '.[] | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"' | slurp)
-  # Check if user exited slurp without selecting the area
-  if [ -z "$GEOM" ]; then
-   exit 1
-  fi
-  WHAT="Area"
-elif [ "$SUBJECT" = "window" ] ; then
-  die "Subject 'window' is now included in 'area'"
+if [ "$ACTION" = "check" ]; then
+	echo "Checking if required tools are installed. If something is missing, install it to your system and make it available in PATH..."
+	check grim
+	check slurp
+	check hyprctl
+	check wl-copy
+	check jq
+	check notify-send
+	exit
+elif [ "$SUBJECT" = "active" ]; then
+	FOCUSED=$(hyprctl activewindow -j)
+	GEOM=$(echo "$FOCUSED" | jq -r '"\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"')
+	APP_ID=$(echo "$FOCUSED" | jq -r '.class')
+	WHAT="$APP_ID window"
+elif [ "$SUBJECT" = "screen" ]; then
+	GEOM=""
+	WHAT="Screen"
+elif [ "$SUBJECT" = "output" ]; then
+	GEOM=""
+	OUTPUT=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true)' | jq -r '.name')
+	WHAT="$OUTPUT"
+elif [ "$SUBJECT" = "area" ]; then
+	WORKSPACES="$(hyprctl monitors -j | jq -r 'map(.activeWorkspace.id)')"
+	WINDOWS="$(hyprctl clients -j | jq -r --argjson workspaces "$WORKSPACES" 'map(select([.workspace.id] | inside($workspaces)))')"
+	GEOM=$(echo "$WINDOWS" | jq -r '.[] | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"' | slurp)
+	# Check if user exited slurp without selecting the area
+	if [ -z "$GEOM" ]; then
+		exit 1
+	fi
+	WHAT="Area"
+elif [ "$SUBJECT" = "window" ]; then
+	die "Subject 'window' is now included in 'area'"
 else
-  die "Unknown subject to take a screen shot from" "$SUBJECT"
+	die "Unknown subject to take a screen shot from" "$SUBJECT"
 fi
 
-if [ "$ACTION" = "copy" ] ; then
-  takeScreenshot - "$GEOM" "$OUTPUT" | wl-copy --type image/png || die "Clipboard error"
-  notifyOk "$WHAT copied to buffer"
-elif [ "$ACTION" = "save" ] ; then
-  if takeScreenshot "$FILE" "$GEOM" "$OUTPUT"; then
-    TITLE="Screenshot of $SUBJECT"
-    MESSAGE=$(basename "$FILE")
-    notifyOk "$MESSAGE" "$TITLE" -i "$FILE"
-    echo "$FILE"
-  else
-    notifyError "Error taking screenshot with grim"
-  fi
-elif [ "$ACTION" = "edit" ] ; then
-  env_editor_confirm
-  if takeScreenshot "$FILE_EDITOR" "$GEOM" "$OUTPUT"; then
-    TITLE="Screenshot of $SUBJECT"
-    MESSAGE="Open screenshot in image editor"
-    notifyOk "$MESSAGE" "$TITLE" -i "$FILE_EDITOR"
-    $GRIMBLAST_EDITOR $FILE_EDITOR
-    echo "$FILE_EDITOR"
-  else
-    notifyError "Error taking screenshot"
-  fi
+if [ "$ACTION" = "copy" ]; then
+	takeScreenshot - "$GEOM" "$OUTPUT" | wl-copy --type image/png || die "Clipboard error"
+	notifyOk "$WHAT copied to buffer"
+elif [ "$ACTION" = "save" ]; then
+	if takeScreenshot "$FILE" "$GEOM" "$OUTPUT"; then
+		TITLE="Screenshot of $SUBJECT"
+		MESSAGE=$(basename "$FILE")
+		notifyOk "$MESSAGE" "$TITLE" -i "$FILE"
+		echo "$FILE"
+	else
+		notifyError "Error taking screenshot with grim"
+	fi
+elif [ "$ACTION" = "edit" ]; then
+	env_editor_confirm
+	if takeScreenshot "$FILE_EDITOR" "$GEOM" "$OUTPUT"; then
+		TITLE="Screenshot of $SUBJECT"
+		MESSAGE="Open screenshot in image editor"
+		notifyOk "$MESSAGE" "$TITLE" -i "$FILE_EDITOR"
+		$GRIMBLAST_EDITOR $FILE_EDITOR
+		echo "$FILE_EDITOR"
+	else
+		notifyError "Error taking screenshot"
+	fi
 else
-  if [ "$ACTION" = "copysave" ] ; then
-    takeScreenshot - "$GEOM" "$OUTPUT" | tee "$FILE" | wl-copy --type image/png || die "Clipboard error"
-    notifyOk "$WHAT copied to buffer and saved to $FILE"
-    echo "$FILE"
-  else
-    notifyError "Error taking screenshot with grim"
-  fi
+	if [ "$ACTION" = "copysave" ]; then
+		takeScreenshot - "$GEOM" "$OUTPUT" | tee "$FILE" | wl-copy --type image/png || die "Clipboard error"
+		notifyOk "$WHAT copied to buffer and saved to $FILE"
+		echo "$FILE"
+	else
+		notifyError "Error taking screenshot with grim"
+	fi
 fi

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -18,45 +18,45 @@
 ## https://github.com/swaywm/sway/blob/master/contrib/grimshot
 
 getTargetDirectory() {
-	test -f "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs" &&
-		. "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs"
+  test -f "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs" &&
+    . "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs"
 
-	echo "${XDG_SCREENSHOTS_DIR:-${XDG_PICTURES_DIR:-$HOME}}"
+  echo "${XDG_SCREENSHOTS_DIR:-${XDG_PICTURES_DIR:-$HOME}}"
 }
 
 tmp_editor_directory() {
-	echo "/tmp"
+  echo "/tmp"
 }
 
 #Detect if $GRIMBLAST_EDITOR env exist
 env_editor_confirm() {
-	if [ -n "$GRIMBLAST_EDITOR" ]; then
-		echo "GRIMBLAST_EDITOR is set. Continuing..."
-	else
-		echo "GRIMBLAST_EDITOR is not set. Defaulting to gimp"
-		GRIMBLAST_EDITOR=gimp
-	fi
+  if [ -n "$GRIMBLAST_EDITOR" ]; then
+    echo "GRIMBLAST_EDITOR is set. Continuing..."
+  else
+    echo "GRIMBLAST_EDITOR is not set. Defaulting to gimp"
+    GRIMBLAST_EDITOR=gimp
+  fi
 }
 
 NOTIFY=no
 CURSOR=
 
 while [ $# -gt 0 ]; do
-	key="$1"
+  key="$1"
 
-	case $key in
-	-n | --notify)
-		NOTIFY=yes
-		shift # past argument
-		;;
-	-c | --cursor)
-		CURSOR=yes
-		shift # past argument
-		;;
-	*)     # unknown option
-		break # done with parsing --flags
-		;;
-	esac
+  case $key in
+  -n | --notify)
+    NOTIFY=yes
+    shift # past argument
+    ;;
+  -c | --cursor)
+    CURSOR=yes
+    shift # past argument
+    ;;
+  *)      # unknown option
+    break # done with parsing --flags
+    ;;
+  esac
 done
 
 ACTION=${1:-usage}
@@ -65,141 +65,141 @@ FILE=${3:-$(getTargetDirectory)/$(date -Ins).png}
 FILE_EDITOR=${3:-$(tmp_editor_directory)/$(date -Ins).png}
 
 if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "edit" ] && [ "$ACTION" != "copysave" ] && [ "$ACTION" != "check" ]; then
-	echo "Usage:"
-	echo "  grimblast [--notify] [--cursor] (copy|save|copysave|edit) [active|screen|output|area] [FILE|-]"
-	echo "  grimblast check"
-	echo "  grimblast usage"
-	echo ""
-	echo "Commands:"
-	echo "  copy: Copy the screenshot data into the clipboard."
-	echo "  save: Save the screenshot to a regular file or '-' to pipe to STDOUT."
-	echo "  copysave: Combine the previous 2 options."
-	echo "  edit: Open screenshot in the image editor of your choice (default is gimp). See man page for info."
-	echo "  check: Verify if required tools are installed and exit."
-	echo "  usage: Show this message and exit."
-	echo ""
-	echo "Targets:"
-	echo "  active: Currently active window."
-	echo "  screen: All visible outputs."
-	echo "  output: Currently active output."
-	echo "  area: Manually select a region or window."
-	exit
+  echo "Usage:"
+  echo "  grimblast [--notify] [--cursor] (copy|save|copysave|edit) [active|screen|output|area] [FILE|-]"
+  echo "  grimblast check"
+  echo "  grimblast usage"
+  echo ""
+  echo "Commands:"
+  echo "  copy: Copy the screenshot data into the clipboard."
+  echo "  save: Save the screenshot to a regular file or '-' to pipe to STDOUT."
+  echo "  copysave: Combine the previous 2 options."
+  echo "  edit: Open screenshot in the image editor of your choice (default is gimp). See man page for info."
+  echo "  check: Verify if required tools are installed and exit."
+  echo "  usage: Show this message and exit."
+  echo ""
+  echo "Targets:"
+  echo "  active: Currently active window."
+  echo "  screen: All visible outputs."
+  echo "  output: Currently active output."
+  echo "  area: Manually select a region or window."
+  exit
 fi
 
 notify() {
-	notify-send -t 3000 -a grimblast "$@"
+  notify-send -t 3000 -a grimblast "$@"
 }
 
 notifyOk() {
-	[ "$NOTIFY" = "no" ] && return
+  [ "$NOTIFY" = "no" ] && return
 
-	notify "$@"
+  notify "$@"
 }
 
 notifyError() {
-	if [ $NOTIFY = "yes" ]; then
-		TITLE=${2:-"Screenshot"}
-		MESSAGE=${1:-"Error taking screenshot with grim"}
-		notify -u critical "$TITLE" "$MESSAGE"
-	else
-		echo "$1"
-	fi
+  if [ $NOTIFY = "yes" ]; then
+    TITLE=${2:-"Screenshot"}
+    MESSAGE=${1:-"Error taking screenshot with grim"}
+    notify -u critical "$TITLE" "$MESSAGE"
+  else
+    echo "$1"
+  fi
 }
 
 die() {
-	MSG=${1:-Bye}
-	notifyError "Error: $MSG"
-	exit 2
+  MSG=${1:-Bye}
+  notifyError "Error: $MSG"
+  exit 2
 }
 
 check() {
-	COMMAND=$1
-	if command -v "$COMMAND" >/dev/null 2>&1; then
-		RESULT="OK"
-	else
-		RESULT="NOT FOUND"
-	fi
-	echo "   $COMMAND: $RESULT"
+  COMMAND=$1
+  if command -v "$COMMAND" >/dev/null 2>&1; then
+    RESULT="OK"
+  else
+    RESULT="NOT FOUND"
+  fi
+  echo "   $COMMAND: $RESULT"
 }
 
 takeScreenshot() {
-	FILE=$1
-	GEOM=$2
-	OUTPUT=$3
-	if [ -n "$OUTPUT" ]; then
-		grim ${CURSOR:+-c} -o "$OUTPUT" "$FILE" || die "Unable to invoke grim"
-	elif [ -z "$GEOM" ]; then
-		grim ${CURSOR:+-c} "$FILE" || die "Unable to invoke grim"
-	else
-		grim ${CURSOR:+-c} -g "$GEOM" "$FILE" || die "Unable to invoke grim"
-	fi
+  FILE=$1
+  GEOM=$2
+  OUTPUT=$3
+  if [ -n "$OUTPUT" ]; then
+    grim ${CURSOR:+-c} -o "$OUTPUT" "$FILE" || die "Unable to invoke grim"
+  elif [ -z "$GEOM" ]; then
+    grim ${CURSOR:+-c} "$FILE" || die "Unable to invoke grim"
+  else
+    grim ${CURSOR:+-c} -g "$GEOM" "$FILE" || die "Unable to invoke grim"
+  fi
 }
 
 if [ "$ACTION" = "check" ]; then
-	echo "Checking if required tools are installed. If something is missing, install it to your system and make it available in PATH..."
-	check grim
-	check slurp
-	check hyprctl
-	check wl-copy
-	check jq
-	check notify-send
-	exit
+  echo "Checking if required tools are installed. If something is missing, install it to your system and make it available in PATH..."
+  check grim
+  check slurp
+  check hyprctl
+  check wl-copy
+  check jq
+  check notify-send
+  exit
 elif [ "$SUBJECT" = "active" ]; then
-	FOCUSED=$(hyprctl activewindow -j)
-	GEOM=$(echo "$FOCUSED" | jq -r '"\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"')
-	APP_ID=$(echo "$FOCUSED" | jq -r '.class')
-	WHAT="$APP_ID window"
+  FOCUSED=$(hyprctl activewindow -j)
+  GEOM=$(echo "$FOCUSED" | jq -r '"\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"')
+  APP_ID=$(echo "$FOCUSED" | jq -r '.class')
+  WHAT="$APP_ID window"
 elif [ "$SUBJECT" = "screen" ]; then
-	GEOM=""
-	WHAT="Screen"
+  GEOM=""
+  WHAT="Screen"
 elif [ "$SUBJECT" = "output" ]; then
-	GEOM=""
-	OUTPUT=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true)' | jq -r '.name')
-	WHAT="$OUTPUT"
+  GEOM=""
+  OUTPUT=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true)' | jq -r '.name')
+  WHAT="$OUTPUT"
 elif [ "$SUBJECT" = "area" ]; then
-	WORKSPACES="$(hyprctl monitors -j | jq -r 'map(.activeWorkspace.id)')"
-	WINDOWS="$(hyprctl clients -j | jq -r --argjson workspaces "$WORKSPACES" 'map(select([.workspace.id] | inside($workspaces)))')"
-	GEOM=$(echo "$WINDOWS" | jq -r '.[] | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"' | slurp)
-	# Check if user exited slurp without selecting the area
-	if [ -z "$GEOM" ]; then
-		exit 1
-	fi
-	WHAT="Area"
+  WORKSPACES="$(hyprctl monitors -j | jq -r 'map(.activeWorkspace.id)')"
+  WINDOWS="$(hyprctl clients -j | jq -r --argjson workspaces "$WORKSPACES" 'map(select([.workspace.id] | inside($workspaces)))')"
+  GEOM=$(echo "$WINDOWS" | jq -r '.[] | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"' | slurp)
+  # Check if user exited slurp without selecting the area
+  if [ -z "$GEOM" ]; then
+    exit 1
+  fi
+  WHAT="Area"
 elif [ "$SUBJECT" = "window" ]; then
-	die "Subject 'window' is now included in 'area'"
+  die "Subject 'window' is now included in 'area'"
 else
-	die "Unknown subject to take a screen shot from" "$SUBJECT"
+  die "Unknown subject to take a screen shot from" "$SUBJECT"
 fi
 
 if [ "$ACTION" = "copy" ]; then
-	takeScreenshot - "$GEOM" "$OUTPUT" | wl-copy --type image/png || die "Clipboard error"
-	notifyOk "$WHAT copied to buffer"
+  takeScreenshot - "$GEOM" "$OUTPUT" | wl-copy --type image/png || die "Clipboard error"
+  notifyOk "$WHAT copied to buffer"
 elif [ "$ACTION" = "save" ]; then
-	if takeScreenshot "$FILE" "$GEOM" "$OUTPUT"; then
-		TITLE="Screenshot of $SUBJECT"
-		MESSAGE=$(basename "$FILE")
-		notifyOk "$TITLE" "$MESSAGE" -i "$FILE"
-		echo "$FILE"
-	else
-		notifyError "Error taking screenshot with grim"
-	fi
+  if takeScreenshot "$FILE" "$GEOM" "$OUTPUT"; then
+    TITLE="Screenshot of $SUBJECT"
+    MESSAGE=$(basename "$FILE")
+    notifyOk "$TITLE" "$MESSAGE" -i "$FILE"
+    echo "$FILE"
+  else
+    notifyError "Error taking screenshot with grim"
+  fi
 elif [ "$ACTION" = "edit" ]; then
-	env_editor_confirm
-	if takeScreenshot "$FILE_EDITOR" "$GEOM" "$OUTPUT"; then
-		TITLE="Screenshot of $SUBJECT"
-		MESSAGE="Open screenshot in image editor"
-		notifyOk "$TITLE" "$MESSAGE" -i "$FILE_EDITOR"
-		$GRIMBLAST_EDITOR "$FILE_EDITOR"
-		echo "$FILE_EDITOR"
-	else
-		notifyError "Error taking screenshot"
-	fi
+  env_editor_confirm
+  if takeScreenshot "$FILE_EDITOR" "$GEOM" "$OUTPUT"; then
+    TITLE="Screenshot of $SUBJECT"
+    MESSAGE="Open screenshot in image editor"
+    notifyOk "$TITLE" "$MESSAGE" -i "$FILE_EDITOR"
+    $GRIMBLAST_EDITOR "$FILE_EDITOR"
+    echo "$FILE_EDITOR"
+  else
+    notifyError "Error taking screenshot"
+  fi
 else
-	if [ "$ACTION" = "copysave" ]; then
-		takeScreenshot - "$GEOM" "$OUTPUT" | tee "$FILE" | wl-copy --type image/png || die "Clipboard error"
-		notifyOk "$WHAT copied to buffer and saved to $FILE" -i "$FILE"
-		echo "$FILE"
-	else
-		notifyError "Error taking screenshot with grim"
-	fi
+  if [ "$ACTION" = "copysave" ]; then
+    takeScreenshot - "$GEOM" "$OUTPUT" | tee "$FILE" | wl-copy --type image/png || die "Clipboard error"
+    notifyOk "$WHAT copied to buffer and saved to $FILE" -i "$FILE"
+    echo "$FILE"
+  else
+    notifyError "Error taking screenshot with grim"
+  fi
 fi

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -89,14 +89,13 @@ fi
 notify() {
 	notify-send -t 3000 -a grimblast "$@"
 }
+
 notifyOk() {
 	[ "$NOTIFY" = "no" ] && return
 
-	TITLE=${2:-"Screenshot"}
-	MESSAGE=${1:-"OK"}
-	REST=${@:3}
-	notify "$TITLE" "$MESSAGE" $REST
+	notify "$@"
 }
+
 notifyError() {
 	if [ $NOTIFY = "yes" ]; then
 		TITLE=${2:-"Screenshot"}
@@ -179,7 +178,7 @@ elif [ "$ACTION" = "save" ]; then
 	if takeScreenshot "$FILE" "$GEOM" "$OUTPUT"; then
 		TITLE="Screenshot of $SUBJECT"
 		MESSAGE=$(basename "$FILE")
-		notifyOk "$MESSAGE" "$TITLE" -i "$FILE"
+		notifyOk "$TITLE" "$MESSAGE" -i "$FILE"
 		echo "$FILE"
 	else
 		notifyError "Error taking screenshot with grim"
@@ -189,8 +188,8 @@ elif [ "$ACTION" = "edit" ]; then
 	if takeScreenshot "$FILE_EDITOR" "$GEOM" "$OUTPUT"; then
 		TITLE="Screenshot of $SUBJECT"
 		MESSAGE="Open screenshot in image editor"
-		notifyOk "$MESSAGE" "$TITLE" -i "$FILE_EDITOR"
-		$GRIMBLAST_EDITOR $FILE_EDITOR
+		notifyOk "$TITLE" "$MESSAGE" -i "$FILE_EDITOR"
+		$GRIMBLAST_EDITOR "$FILE_EDITOR"
 		echo "$FILE_EDITOR"
 	else
 		notifyError "Error taking screenshot"
@@ -198,7 +197,7 @@ elif [ "$ACTION" = "edit" ]; then
 else
 	if [ "$ACTION" = "copysave" ]; then
 		takeScreenshot - "$GEOM" "$OUTPUT" | tee "$FILE" | wl-copy --type image/png || die "Clipboard error"
-		notifyOk "$WHAT copied to buffer and saved to $FILE"
+		notifyOk "$WHAT copied to buffer and saved to $FILE" -i "$FILE"
 		echo "$FILE"
 	else
 		notifyError "Error taking screenshot with grim"

--- a/grimblast/screenshot.sh
+++ b/grimblast/screenshot.sh
@@ -41,184 +41,179 @@ save=' Save'
 copy_save='Copy & Save'
 edit='Edit Screenshot'
 
-
 # Rofi CMD
 rofi_cmd() {
-	rofi -theme-str "window {width: $win_width;}" \
-		-theme-str "listview {columns: $list_col; lines: $list_row;}" \
-		-theme-str 'textbox-prompt-colon {str: "";}' \
-		-dmenu \
-		-p "$prompt" \
-		-mesg "$mesg" \
-		-markup-rows
+  rofi -theme-str "window {width: $win_width;}" \
+    -theme-str "listview {columns: $list_col; lines: $list_row;}" \
+    -theme-str 'textbox-prompt-colon {str: "";}' \
+    -dmenu \
+    -p "$prompt" \
+    -mesg "$mesg" \
+    -markup-rows
 }
 
 # Pass variables to rofi dmenu
 run_rofi() {
-	echo -e "$option_1\n$option_2" | rofi_cmd
+  echo -e "$option_1\n$option_2" | rofi_cmd
 }
 
 ####
 # Choose Timer
 # CMD
-timer_cmd () {
-	rofi -theme-str 'window {location: center; anchor: center; fullscreen: false; width: 400px;}' \
-		-theme-str 'mainbox {orientation: vertical; children: [ "message", "listview" ];}' \
-		-theme-str 'listview {columns: 1; lines: 5;}' \
-		-theme-str 'element-text {horizontal-align: 0.5;}' \
-		-theme-str 'textbox {horizontal-align: 0.5;}' \
-		-dmenu \
-		-p 'Choose Option' \
-		-mesg 'Choose timer:'
+timer_cmd() {
+  rofi -theme-str 'window {location: center; anchor: center; fullscreen: false; width: 400px;}' \
+    -theme-str 'mainbox {orientation: vertical; children: [ "message", "listview" ];}' \
+    -theme-str 'listview {columns: 1; lines: 5;}' \
+    -theme-str 'element-text {horizontal-align: 0.5;}' \
+    -theme-str 'textbox {horizontal-align: 0.5;}' \
+    -dmenu \
+    -p 'Choose Option' \
+    -mesg 'Choose timer:'
 }
 
 # Ask for confirmation
 timer_exit() {
-	echo -e "$option_time_1\n$option_time_2\n$option_time_3\n$option_time_4\n$option_time_5" | timer_cmd
+  echo -e "$option_time_1\n$option_time_2\n$option_time_3\n$option_time_4\n$option_time_5" | timer_cmd
 }
 
 # Confirm and execute
-timer_run () {	
-	selected_timer="$(timer_exit)"
-	if [[ "$selected_timer" == "$option_time_1" ]]; then
-		countdown=5
-    	${1}
-	elif [[ "$selected_timer" == "$option_time_2" ]]; then
-		countdown=10
-    	${1}
-	elif [[ "$selected_timer" == "$option_time_3" ]]; then
-		countdown=20
-        ${1}
-    elif [[ "$selected_timer" == "$option_time_4" ]]; then
-       countdown=30
-        ${1}
-	elif [[ "$selected_timer" == "$option_time_5" ]]; then
-    	countdown=60
-        ${1}
-    fi	
+timer_run() {
+  selected_timer="$(timer_exit)"
+  if [[ "$selected_timer" == "$option_time_1" ]]; then
+    countdown=5
+    ${1}
+  elif [[ "$selected_timer" == "$option_time_2" ]]; then
+    countdown=10
+    ${1}
+  elif [[ "$selected_timer" == "$option_time_3" ]]; then
+    countdown=20
+    ${1}
+  elif [[ "$selected_timer" == "$option_time_4" ]]; then
+    countdown=30
+    ${1}
+  elif [[ "$selected_timer" == "$option_time_5" ]]; then
+    countdown=60
+    ${1}
+  fi
 }
 ###
 
 ####
 # Chose Screenshot Type
 # CMD
-type_screenshot_cmd () {
-	rofi -theme-str 'window {location: center; anchor: center; fullscreen: false; width: 400px;}' \
-		-theme-str 'mainbox {orientation: vertical; children: [ "message", "listview" ];}' \
-		-theme-str 'listview {columns: 1; lines: 3;}' \
-		-theme-str 'element-text {horizontal-align: 0.5;}' \
-		-theme-str 'textbox {horizontal-align: 0.5;}' \
-		-dmenu \
-		-p 'Choose Option' \
-		-mesg 'Type Of Screenshot:'
+type_screenshot_cmd() {
+  rofi -theme-str 'window {location: center; anchor: center; fullscreen: false; width: 400px;}' \
+    -theme-str 'mainbox {orientation: vertical; children: [ "message", "listview" ];}' \
+    -theme-str 'listview {columns: 1; lines: 3;}' \
+    -theme-str 'element-text {horizontal-align: 0.5;}' \
+    -theme-str 'textbox {horizontal-align: 0.5;}' \
+    -dmenu \
+    -p 'Choose Option' \
+    -mesg 'Type Of Screenshot:'
 }
 
 # Ask for confirmation
 type_screenshot_exit() {
-	echo -e "$option_capture_1\n$option_capture_2\n$option_capture_3" | type_screenshot_cmd
+  echo -e "$option_capture_1\n$option_capture_2\n$option_capture_3" | type_screenshot_cmd
 }
 
 # Confirm and execute
-type_screenshot_run () {	
-	selected_type_screenshot="$(type_screenshot_exit)"
-	if [[ "$selected_type_screenshot" == "$option_capture_1" ]]; then
-		option_type_screenshot=screen
-    	${1}
-	elif [[ "$selected_type_screenshot" == "$option_capture_2" ]]; then
-		option_type_screenshot=output
-    	${1}
-	elif [[ "$selected_type_screenshot" == "$option_capture_3" ]]; then
-		option_type_screenshot=area
-        ${1}
-    fi	
+type_screenshot_run() {
+  selected_type_screenshot="$(type_screenshot_exit)"
+  if [[ "$selected_type_screenshot" == "$option_capture_1" ]]; then
+    option_type_screenshot=screen
+    ${1}
+  elif [[ "$selected_type_screenshot" == "$option_capture_2" ]]; then
+    option_type_screenshot=output
+    ${1}
+  elif [[ "$selected_type_screenshot" == "$option_capture_3" ]]; then
+    option_type_screenshot=area
+    ${1}
+  fi
 }
 ###
 
 ####
 # Choose to save or copy photo
 # CMD
-copy_save_editor_cmd () {
-	rofi -theme-str 'window {location: center; anchor: center; fullscreen: false; width: 400px;}' \
-		-theme-str 'mainbox {orientation: vertical; children: [ "message", "listview" ];}' \
-		-theme-str 'listview {columns: 2; lines: 2;}' \
-		-theme-str 'element-text {horizontal-align: 0.5;}' \
-		-theme-str 'textbox {horizontal-align: 0.5;}' \
-		-dmenu \
-		-p 'Choose Option' \
-		-mesg 'Copy/save the screenshot or open in image editor'
+copy_save_editor_cmd() {
+  rofi -theme-str 'window {location: center; anchor: center; fullscreen: false; width: 400px;}' \
+    -theme-str 'mainbox {orientation: vertical; children: [ "message", "listview" ];}' \
+    -theme-str 'listview {columns: 2; lines: 2;}' \
+    -theme-str 'element-text {horizontal-align: 0.5;}' \
+    -theme-str 'textbox {horizontal-align: 0.5;}' \
+    -dmenu \
+    -p 'Choose Option' \
+    -mesg 'Copy/save the screenshot or open in image editor'
 }
 
 # Ask for confirmation
 copy_save_editor_exit() {
-	echo -e "$copy\n$save\n$copy_save\n$edit" | copy_save_editor_cmd
+  echo -e "$copy\n$save\n$copy_save\n$edit" | copy_save_editor_cmd
 }
 
 # Confirm and execute
-copy_save_editor_run () {	
-	selected_chosen="$(copy_save_editor_exit)"
-	if [[ "$selected_chosen" == "$copy" ]]; then
-		option_chosen=copy
-    	${1}
-	elif [[ "$selected_chosen" == "$save" ]]; then
-		option_chosen=save
-    	${1}
-	elif [[ "$selected_chosen" == "$copy_save" ]]; then
-		option_chosen=copysave
-        ${1}
-    elif [[ "$selected_chosen" == "$edit" ]]; then
-        option_chosen=edit
-        ${1}
-    fi	
+copy_save_editor_run() {
+  selected_chosen="$(copy_save_editor_exit)"
+  if [[ "$selected_chosen" == "$copy" ]]; then
+    option_chosen=copy
+    ${1}
+  elif [[ "$selected_chosen" == "$save" ]]; then
+    option_chosen=save
+    ${1}
+  elif [[ "$selected_chosen" == "$copy_save" ]]; then
+    option_chosen=copysave
+    ${1}
+  elif [[ "$selected_chosen" == "$edit" ]]; then
+    option_chosen=edit
+    ${1}
+  fi
 }
 ###
 
-timer () {
-	if [[ $countdown -gt 10 ]]; then
-		notify-send -t 1000 "Taking Screenshot in ${countdown} seconds"
-		countdown_less_10=$(( $countdown - 10 ))
-		sleep $countdown_less_10
-		countdown=10
-	else
-		:
-	fi
-	while [[ $countdown -ne 0 ]]; do
-		notify-send -t 1000 "Taking Screenshot in ${countdown}"
-		countdown=$(( $countdown - 1 ))
-		sleep 1
-	done
+timer() {
+  if [[ $countdown -gt 10 ]]; then
+    notify-send -t 1000 "Taking Screenshot in ${countdown} seconds"
+    countdown_less_10=$((countdown - 10))
+    sleep $countdown_less_10
+    countdown=10
+  fi
+  while [[ $countdown -ne 0 ]]; do
+    notify-send -t 1000 "Taking Screenshot in ${countdown}"
+    countdown=$((countdown - 1))
+    sleep 1
+  done
 }
 
 # take shots
-takescreenshot () {
-	grimblast --notify $option_chosen $option_type_screenshot
+takescreenshot() {
+  grimblast --notify "$option_chosen" "$option_type_screenshot"
 }
 
-takescreenshot_timer () {
-	timer
-	grimblast --notify $option_chosen $option_type_screenshot
+takescreenshot_timer() {
+  timer
+  grimblast --notify "$option_chosen" "$option_type_screenshot"
 }
 
 # Execute Command
 run_cmd() {
-	if [[ "$1" == '--opt1' ]]; then
-		type_screenshot_run 
-		copy_save_editor_run "takescreenshot"
-	elif [[ "$1" == '--opt2' ]]; then
-		timer_run 
-		type_screenshot_run 
-		copy_save_editor_run "takescreenshot_timer"
-	fi
+  if [[ "$1" == '--opt1' ]]; then
+    type_screenshot_run
+    copy_save_editor_run "takescreenshot"
+  elif [[ "$1" == '--opt2' ]]; then
+    timer_run
+    type_screenshot_run
+    copy_save_editor_run "takescreenshot_timer"
+  fi
 }
 
 # Actions
 chosen="$(run_rofi)"
 case ${chosen} in
-    $option_1)
-		run_cmd --opt1
-        ;;
-    $option_2)
-		run_cmd --opt2
-        ;;
+$option_1)
+  run_cmd --opt1
+  ;;
+$option_2)
+  run_cmd --opt2
+  ;;
 esac
-
-


### PR DESCRIPTION
There were some issues in the GRIMBLAST_EDITOR check function.
no matter if the variable is in env or not it is used to use gimp.
Fixed that.
and made notifications to show image previews if possible.
now users can use `GRIMBLAST_EDITOR="swappy -f"`