### PR TITLE
Add hyprprop

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,4 +16,4 @@ jobs:
           extra_nix_config: |
             auto-optimise-store = true
             experimental-features = nix-command flakes
-      - run: nix run nixpkgs#shellcheck -- -S error grimblast/grimblast shellevents/shellevents shellevents/*.sh grimblast/screenshot.sh scratchpad/scratchpad
+      - run: nix run nixpkgs#shellcheck -- -S error grimblast/grimblast shellevents/shellevents shellevents/*.sh grimblast/screenshot.sh scratchpad/scratchpad hyprprop/hyprprop

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
   in {
     overlays.default = _: prev: {
       grimblast = prev.callPackage ./grimblast {hyprland = null;};
+      hyprprop = prev.callPackage ./hyprprop {};
       scratchpad = prev.callPackage ./scratchpad {hyprland = null;};
       shellevents = prev.callPackage ./shellevents {hyprland = null;};
     };

--- a/hyprprop/.gitignore
+++ b/hyprprop/.gitignore
@@ -1,0 +1,1 @@
+hyprprop.1

--- a/hyprprop/Makefile
+++ b/hyprprop/Makefile
@@ -1,0 +1,12 @@
+PREFIX ?= /usr
+BINDIR ?= $(PREFIX)/bin
+MANDIR ?= $(PREFIX)/share/man
+
+all: hyprprop.1
+
+hyprprop.1: hyprprop.1.scd
+	scdoc < $< > $@
+
+install: hyprprop.1 hyprprop
+	@install -v -D -m 0644 hyprprop.1 --target-directory "$(MANDIR)/man1"
+	@install -v -D -m 0755 hyprprop --target-directory "$(BINDIR)"

--- a/hyprprop/default.nix
+++ b/hyprprop/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  coreutils,
+  scdoc,
+  makeWrapper,
+  slurp,
+  jq,
+  bash,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "hyprprop";
+  version = "0.1";
+  src = ./.;
+
+  buildInputs = [bash scdoc];
+  makeFlags = ["PREFIX=$(out)"];
+  nativeBuildInputs = [makeWrapper];
+
+  postInstall = ''
+    wrapProgram $out/bin/hyprprop --prefix PATH ':' \
+      "${lib.makeBinPath [
+      coreutils
+      slurp
+      jq
+    ]}"
+  '';
+
+  meta = with lib; {
+    description = "An xprop replacement for Hyprland";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [fufexan];
+  };
+}

--- a/hyprprop/hyprprop
+++ b/hyprprop/hyprprop
@@ -1,0 +1,96 @@
+#!/bin/sh
+## Hyprprop: a xprop replacement for hyprland
+## Requirements:
+##  - `slurp`: to select an area
+##  - `hyprctl`: to read properties of current window
+##  - `jq`: json utility to parse hyprctl output
+##
+## See `man 1 hyprprop` for further details
+
+## Author: Douile (https://github.com/Douile)
+
+## The window selection part (and others) of this tool is based on grimblast
+## https://github.com/hyprwm/contrib/blob/main/grimblast
+
+set -eu
+
+check() {
+  COMMAND=$1
+  if command -v "$COMMAND" >/dev/null 2>&1; then
+    RESULT="OK"
+  else
+    RESULT="NOT FOUND"
+  fi
+  echo "   $COMMAND: $RESULT"
+}
+
+# https://www.shellcheck.net/wiki/SC2086
+jq_with_flags() {
+  if [ "$RAW" = "yes" ]; then
+    set -- --compact-output "$@"
+    set -- --monochrome-output "$@"
+  fi
+  jq "$@"
+}
+
+CHECK=no
+HELP=no
+ID=""
+RAW=no
+
+while [ $# -gt 0 ]; do
+  key="$1"
+  case "$key" in
+  -c | --check)
+    CHECK=yes
+    shift
+    ;;
+  -h | --help)
+    HELP=yes
+    shift
+    ;;
+  --id)
+    shift
+    ID="$1"
+    shift
+    ;;
+  -r | --raw)
+    RAW=yes
+    shift
+    ;;
+  *)
+    break
+    ;;
+  esac
+done
+
+if [ "$HELP" = "yes" ]; then
+  echo "Hyprprop: View window information of selected window"
+  echo "Usage:"
+  echo "  hyprprop [--help] [--check] [--id id] [--raw]"
+  echo ""
+  echo "Flags:"
+  echo "  --help    : Print help information"
+  echo "  --check   : Check dependencies are installed"
+  echo "  --id <id> : Print information for window ID, skip selection, e.g. 0x1d0503e0"
+  echo "  --raw     : Output raw JSON data"
+  echo ""
+  exit
+elif [ "$CHECK" = "yes" ]; then
+  check slurp
+  check hyprctl
+  check jq
+  exit
+fi
+
+WORKSPACES="$(hyprctl monitors -j | jq -r 'map(.activeWorkspace.id)')"
+WINDOWS="$(hyprctl clients -j | jq -r --argjson workspaces "$WORKSPACES" 'map(select([.workspace.id] | inside($workspaces)))')"
+
+if [ "$ID" = "" ]; then
+  ID=$(printf "%s" "$WINDOWS" | jq -r '.[] | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1]) \(.address)"' | slurp -f "%l")
+fi
+
+# NOTE: We don't want to expand the expression as it is an argument used by jq
+# shellcheck disable=SC2016
+printf "%s" "$WINDOWS" | jq_with_flags --arg id "$ID" '.[] | select(.address == $id)'
+

--- a/hyprprop/hyprprop.1.scd
+++ b/hyprprop/hyprprop.1.scd
@@ -1,0 +1,72 @@
+hyprprop(1)
+
+# NAME
+
+hyprprop - A replacement for xprop within hyprland
+
+# SYNOPSIS
+
+*hyprprop* [--help] [--check] [--id id] [--raw]
+
+# OPTIONS
+
+*--help*
+	Show command help
+
+*--check*
+	Check dependencies are installed
+
+*--id id*
+	Skip selecting a window, get information for given ID
+
+*--raw*
+	Output raw JSON data
+
+# DESCRIPTION
+
+Hyprprop is a interactive window information utility, based on grimblast.
+It allows you to view properties hyprland knows about a window you click.
+
+# EXAMPLES
+
+An example of using hyprprop
+```
+$ hyprprop
+{
+  "address": "0x1d0503e0",
+  "mapped": true,
+  "hidden": false,
+  "at": [
+    1063,
+    1140
+  ],
+  "size": [
+    835,
+    492
+  ],
+  "workspace": {
+    "id": 6,
+    "name": "6"
+  },
+  "floating": false,
+  "monitor": 0,
+  "class": "Alacritty",
+  "title": "Alacritty",
+  "pid": 57833,
+  "xwayland": false,
+  "pinned": false,
+  "fullscreen": false,
+  "fullscreenMode": 0,
+  "fakeFullscreen": false,
+  "grouped": [],
+  "swallowing": null
+}
+```
+
+# OUTPUT
+
+Hyprprop will output formatted JSON returned from hyprctl about the selected window.
+
+# SEE ALSO
+
+*xprop*(1)


### PR DESCRIPTION
Adds hyprprop, a xprop replacement for hyprland, it allows you to select a window to view its properties from hyprctl.

Useful for getting information for window rules and checking if things are using xwayland.

![hyprprop](https://user-images.githubusercontent.com/25043847/225653075-9fba5660-75ad-409b-bb3c-537c65a7cab4.gif)
