### PR TITLE
hyprprop: Add a desktop item

### DIFF
--- a/hyprprop/default.nix
+++ b/hyprprop/default.nix
@@ -5,9 +5,20 @@
   scdoc,
   makeWrapper,
   slurp,
+  makeDesktopItem,
+  copyDesktopItems,
   jq,
   bash,
 }:
+let
+  desktopItem = makeDesktopItem {
+    name = "hyprprop";
+    exec = "hyprprop";
+    desktopName = "Hyprprop";
+    terminal=true;
+    startupNotify = false;
+  };
+in
 stdenvNoCC.mkDerivation {
   pname = "hyprprop";
   version = "0.1";
@@ -15,7 +26,7 @@ stdenvNoCC.mkDerivation {
 
   buildInputs = [bash scdoc];
   makeFlags = ["PREFIX=$(out)"];
-  nativeBuildInputs = [makeWrapper];
+  nativeBuildInputs = [makeWrapper copyDesktopItems];
 
   postInstall = ''
     wrapProgram $out/bin/hyprprop --prefix PATH ':' \
@@ -25,6 +36,8 @@ stdenvNoCC.mkDerivation {
       jq
     ]}"
   '';
+
+  desktopItems = [ desktopItem ];
 
   meta = with lib; {
     description = "An xprop replacement for Hyprland";


### PR DESCRIPTION
With this PR, you can run hyprprop inside a terminal from a launcher like `fuzzel`.

An example configuration is as follows:

```sh
bind = $mod, Space, exec, fuzzel -T "footclient -H"
```