### PR TITLE
add feature try_switch_workspace

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,4 +16,4 @@ jobs:
           extra_nix_config: |
             auto-optimise-store = true
             experimental-features = nix-command flakes
-      - run: nix run nixpkgs#shellcheck -- -S error grimblast/grimblast shellevents/shellevents shellevents/*.sh grimblast/screenshot.sh scratchpad/scratchpad hyprprop/hyprprop
+      - run: nix run nixpkgs#shellcheck -- -S error grimblast/grimblast shellevents/shellevents shellevents/*.sh grimblast/screenshot.sh scratchpad/scratchpad hyprprop/hyprprop try_swap_workspace/try_swap_workspace

--- a/README.md
+++ b/README.md
@@ -16,6 +16,24 @@ Invoke shell functions in response to Hyprland socket2 events. Install with `mak
 
 See `shellevents_default.sh` for the supported function names. Example event files can be found in `submaps.sh` and `notifywindow.sh`.
 
+## try_swap_workspace
+
+Inspired from [this discussion on the hyprland repository](https://github.com/hyprwm/Hyprland/discussions/835) try_swap_workspace is a binding to mimic the 'arbitrary workspace on arbitrary monitor' on arbitrary monitor behavior known from may window managers.
+This means:
+- if a workspace is not displayed on any monitor and should be displayed, it gets displayed on the currently focused monitor
+- if a workspace is already displayed on another monitor and should displayed on the currently focused monitor, the displayed workspace on the focused monitor will be swapped with the workspace on the monitor that should be displayed on the focused monitor
+
+Install by running the Makefile `sudo make install`
+Uninstall by running the Makefile `sudo make uninstall`
+
+Usage:
+
+To send the window to scratchpad
+> bind= ALT,1,exec, try_swap_workspace 1
+
+use `-h` flag to get help.
+use `-c` flag to check dependencies
+
 ## Scratchpad
 A Bash script that instantly sends focused window to a special workspace named `scratchpad`
 and makes it easier to retrieve the window back to the current workspace.

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
       hyprprop = prev.callPackage ./hyprprop {};
       scratchpad = prev.callPackage ./scratchpad {hyprland = null;};
       shellevents = prev.callPackage ./shellevents {hyprland = null;};
+      try_swap_workspace = prev.callPackage ./try_swap_workspace {};
     };
 
     packages = genSystems (system: self.overlays.default null pkgsFor.${system});

--- a/try_swap_workspace/Makefile
+++ b/try_swap_workspace/Makefile
@@ -1,0 +1,8 @@
+PREFIX ?= /usr
+BINDIR ?= $(PREFIX)/bin
+
+install: try_swap_workspace
+	@install -v -D -m 0755 try_swap_workspace --target-directory "$(BINDIR)"
+
+uninstall: try_swap_workspace
+	rm "$(BINDIR)/try_swap_workspace"

--- a/try_swap_workspace/default.nix
+++ b/try_swap_workspace/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenvNoCC,
+  coreutils,
+  scdoc,
+  makeShellWrapper,
+  libnotify,
+  bash,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "try_swap_workspace";
+  version = "0.1";
+  src = ./.;
+
+  buildInputs = [bash scdoc];
+  makeFlags = ["PREFIX=$(out)"];
+  nativeBuildInputs = [makeShellWrapper];
+
+  postInstall = ''
+    wrapProgramShell $out/bin/try_swap_workspace --prefix PATH ':' \
+      "${lib.makeBinPath [
+      coreutils
+      libnotify
+    ]}"
+  '';
+
+  meta = with lib; {
+    description = "Workspace switching helper for Hyprland";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [fufexan];
+  };
+}

--- a/try_swap_workspace/try_swap_workspace
+++ b/try_swap_workspace/try_swap_workspace
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+# Pascal Jaeger <pascal.jaeger@leimstift.de>
+
+# utils
+green="\033[0;32m"
+red="\033[0;31m"
+blue="\033[0;34m"
+nocolor="\033[0m"
+
+#util functions
+check() {
+	command -v "$1" 1>/dev/null
+}
+
+ok() {
+	echo -e "[$green  $nocolor] $*"
+}
+
+err() {
+	echo -e "[$red  $nocolor] $*"
+}
+optional() {
+	echo -e "[$blue  $nocolor] $*"
+}
+
+notify() {
+	# shellcheck disable=SC2015
+	check notify-send && {
+		notify-send "$@"
+	} || {
+		echo "$@"
+	}
+}
+
+checkUtils() {
+	# shellcheck disable=SC2015
+	check grep && ok "grep" || err "grep"
+	# shellcheck disable=SC2015
+	check grep && ok "cut" || err "cut"
+	# shellcheck disable=SC2015
+	check notify-send && ok "notify-send (Optional)" || optional "notify-send (Optional)"
+	exit
+}
+
+basicChecks() {
+	check hyprctl || {
+		notify "Seriously mate!!" "Start Hyprland before this script"
+		exit 1
+	}
+	pgrep -x Hyprland &>/dev/null || {
+		notify "Make Sure Hyprland Session is running."
+		exit 1
+	}
+}
+
+help() {
+	cat <<EOF
+  This is a bash script to move arbitrary workspace to arbritrary monitor and to swap workspaces between
+  monitors if the desired workspace is already active on a monitor for Hyprland using hyprctl.
+
+  flags:
+    -h: Displays This help menu
+    -c: Checks for all dependencies
+
+  Usage: try_swap_workspace [WORKSPACE]
+    bind = ALT,1,exec, /path/to/try_swap_workspace/binary 1
+    (where the last 1 is the workspace that should be shown on the currently active monitor)
+
+EOF
+}
+
+getArgs() {
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+		-h | --help)
+			help
+			exit 0
+			;;
+		-c)
+			checkUtils
+			;;
+    (*[!0-9]*)
+      # contains non-numbers
+      help
+      echo ""
+      echo "Wrong argument given"
+      exit 1
+      ;;
+    *)
+      # only nubers left, so good
+      switch_or_swap "$1"
+      ;;
+    esac
+    shift
+  done
+}
+
+
+#variables
+mon_wrkspcs=()
+
+get_active_mon() {
+  echo $(($(hyprctl monitors | grep 'focused' | grep -n 'yes' | cut -c1)-1))
+}
+
+get_workspaces_array() {
+  local workspaces
+  workspaces=$(hyprctl monitors | grep 'active workspace' | cut -f3 -d' ')
+  SAVEIFS=$IFS
+  IFS=$'\n'
+  mon_wrkspcs=($workspaces)
+  IFS=$SAVEIFS
+}
+
+# first argument: workspace to switch to
+# second argument: monitor to switch workspace on
+switch_workspace() {
+  local target_wrkspc=$1
+  local target_mon=$2
+  hyprctl dispatch moveworkspacetomonitor "$target_wrkspc" "$target_mon"
+  hyprctl dispatch workspace "$target_wrkspc"
+}
+# first argument: monitor the workspace should go to
+# second argument: monitor the workspace is currently displayed on
+swap_workspace() {
+  local target_mon=$1
+  local source_mon=$2
+  hyprctl dispatch swapactiveworkspaces "$target_mon" "$source_mon"
+}
+
+# first argument: workspace to switch to active monitor
+switch_or_swap() {
+  target_mon=$(get_active_mon)
+  target_wrkspc=$1
+  get_workspaces_array
+  # check if the workspace is currently displayed on another monitor
+  local currently_active_on_mon=-1
+  for (( i=0; i<${#mon_wrkspcs[@]}; i++ ))
+  do
+    if [[ "$target_wrkspc" == "${mon_wrkspcs[$i]}" ]]; then
+      currently_active_on_mon=$i
+    fi
+  done
+  if [[ $currently_active_on_mon -lt 0 ]]; then
+    # workspace is not active on any monitor, do a normal switch
+    ok "switching workspace $target_wrkspc to monitor $target_mon"
+    switch_workspace "$target_wrkspc" "$target_mon"
+  else
+    # workspace is already active on other monitor, swap workspaces between monitor
+    ok "swapping workspaces between $target_mon to monitor $currently_active_on_mon"
+    swap_workspace "$target_mon" "$currently_active_on_mon"
+  fi
+}
+
+main() {
+  basicChecks
+  getArgs "$@"
+}
+
+main "$@"


### PR DESCRIPTION
Hey :wave: 

Inspired from [this discussion on the hyprland repository](https://github.com/hyprwm/Hyprland/discussions/835) try_swap_workspace is a binding to mimic the 'arbitrary workspace on arbitrary monitor' on arbitrary monitor behavior known from may window managers.
This means:
- if a workspace is not displayed on any monitor and should be displayed, it gets displayed on the currently focused monitor
- if a workspace is already displayed on another monitor and should displayed on the currently focused monitor, the displayed workspace on the focused monitor will be swapped with the workspace on the monitor that should be displayed on the focused monitor

I hope this helps some people that want hyprland to behave like their old windowmanager. (For me that was xmonad). I tried to mimic the existing script for scratchpatch as much as possible, I don't know how to write nix packages, though. So I skipped that. 

I think the explanation already describes it well enough, but let me know if you want a screen recording. I have to figure out how to do that first then.
If people come up with any other modes of how workspaces and windows should behave with multi monitors (I am bad in imagining them, but people come up with new weird stuff all the time) we can probably add some extra flags to this script to change behavior. For now lets keep it simple. 

Cheers! :tada:  