### PR TITLE
grimblast: add --freeze argument

### DIFF
--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -40,6 +40,7 @@ env_editor_confirm() {
 
 NOTIFY=no
 CURSOR=
+FREEZE=
 
 while [ $# -gt 0 ]; do
   key="$1"
@@ -51,6 +52,10 @@ while [ $# -gt 0 ]; do
     ;;
   -c | --cursor)
     CURSOR=yes
+    shift # past argument
+    ;;
+  -f | --freeze)
+    FREEZE=yes
     shift # past argument
     ;;
   *)      # unknown option
@@ -66,7 +71,7 @@ FILE_EDITOR=${3:-$(tmp_editor_directory)/$(date -Ins).png}
 
 if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "edit" ] && [ "$ACTION" != "copysave" ] && [ "$ACTION" != "check" ]; then
   echo "Usage:"
-  echo "  grimblast [--notify] [--cursor] (copy|save|copysave|edit) [active|screen|output|area] [FILE|-]"
+  echo "  grimblast [--notify] [--cursor] [--freeze] (copy|save|copysave|edit) [active|screen|output|area] [FILE|-]"
   echo "  grimblast check"
   echo "  grimblast usage"
   echo ""
@@ -140,6 +145,7 @@ if [ "$ACTION" = "check" ]; then
   check grim
   check slurp
   check hyprctl
+  check hyprpicker
   check wl-copy
   check jq
   check notify-send
@@ -157,9 +163,21 @@ elif [ "$SUBJECT" = "output" ]; then
   OUTPUT=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true)' | jq -r '.name')
   WHAT="$OUTPUT"
 elif [ "$SUBJECT" = "area" ]; then
+  if [ "$FREEZE" = "yes" ] && [ "$(command -v "hyprpicker")" ] >/dev/null 2>&1; then
+    hyprpicker -r -z &
+    sleep 0.2
+    hyprpicker_pid=$!
+  else
+    hyprpicker_pid=-1
+  fi
+
   WORKSPACES="$(hyprctl monitors -j | jq -r 'map(.activeWorkspace.id)')"
   WINDOWS="$(hyprctl clients -j | jq -r --argjson workspaces "$WORKSPACES" 'map(select([.workspace.id] | inside($workspaces)))')"
   GEOM=$(echo "$WINDOWS" | jq -r '.[] | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"' | slurp)
+
+  if [ ! $hyprpicker_pid -eq -1 ]; then
+    kill $hyprpicker_pid
+  fi
   # Check if user exited slurp without selecting the area
   if [ -z "$GEOM" ]; then
     exit 1


### PR DESCRIPTION
Fixes #37

Adds `-f | --freeze` flag (only works in `area` mode). This freezes the screen using `hyprpicker -r -z` so make sure you have that installed. As always, `grimblast check` tells you whether you're missing anything.