### PR TITLE
feat(scratchpad): Minor improvements

### DIFF
--- a/scratchpad/scratchpad
+++ b/scratchpad/scratchpad
@@ -95,7 +95,7 @@ getBack() {
 	_ifs="$IFS"
 	IFS=$'\n'$'\n'
 
-        if pgrep "${_menu_cmd%% *}" >/dev/null; then exit fi # Menu running already? → exit
+        if pgrep "${_menu_cmd%% *}" >/dev/null; then exit; fi # Menu running already? → exit
 
 	_current_workspace="$(hyprctl monitors -j | jq '.[] | select(.focused==true)' | jq -j '.activeWorkspace.name')"
 

--- a/scratchpad/scratchpad
+++ b/scratchpad/scratchpad
@@ -4,7 +4,7 @@
 
 # Variables
 _listing=false
-_menu_cmd="rofi -dmenu -i"
+_menu_cmd="rofi -dmenu -i -p scratchpad"
 green="\033[0;32m"
 red="\033[0;31m"
 blue="\033[0;34m"
@@ -94,6 +94,8 @@ takes() {
 getBack() {
 	_ifs="$IFS"
 	IFS=$'\n'$'\n'
+
+        if pgrep "${_menu_cmd%% *}" >/dev/null; then exit fi # Menu running already? → exit
 
 	_current_workspace="$(hyprctl monitors -j | jq '.[] | select(.focused==true)' | jq -j '.activeWorkspace.name')"
 


### PR DESCRIPTION
* Rofi shows "scratchpad" as title instead of "dmenu".
* If menu is running already, don't try to run it again.