### PR TITLE
fix: hdrop valid license

### DIFF
--- a/hdrop/default.nix
+++ b/hdrop/default.nix
@@ -33,7 +33,7 @@ stdenvNoCC.mkDerivation {
 
   meta = with lib; {
     description = "Emulate 'tdrop' in Hyprland (show and hide specific programs per keybind)";
-    license = licenses.agpl;
+    license = licenses.agpl3;
     platforms = platforms.unix;
     # maintainers = with maintainers; [];
     mainProgram = "hdrop";


### PR DESCRIPTION
```
error: attribute 'agpl' missing

       at /nix/store/blnk3ibcrb52nj2wvcn6any566h1j5aj-source/hdrop/default.nix:36:15:

           35|     description = "Emulate 'tdrop' in Hyprland (show and hide specific programs per keybind)";
           36|     license = licenses.agpl;
             |               ^
           37|     platforms = platforms.unix;
       Did you mean one of agpl3, eapl, gfl, gpl2 or gpl3?
```

https://github.com/Schweber/hdrop/blob/main/LICENSE