### PR TITLE
Changed `movetoworkspace` to `movetoworkspacesilent`

### DIFF
--- a/scratchpad/scratchpad
+++ b/scratchpad/scratchpad
@@ -133,7 +133,7 @@ getBack() {
 }
 
 send() {
-  hyprctl dispatch movetoworkspace "special:scratchpad"
+  hyprctl dispatch movetoworkspacesilent "special:scratchpad"
 }
 
 getArgs() {


### PR DESCRIPTION
Now sending window to scratchpad will not switch to scratchpad workspace