### PR TITLE
hdrop: fix make install in Makefile

### DIFF
--- a/hdrop/Makefile
+++ b/hdrop/Makefile
@@ -11,7 +11,7 @@ all: hdrop.1
 hdrop.1: hdrop.1.scd
 	scdoc < $< > $@
 
-install: 
+install: hdrop.1 hdrop
 	@install -v -D -m 0644 hdrop.1 --target-directory "$(MAN1DIR)"
 	@install -v -D -m 0755 hdrop --target-directory "$(BINDIR)"
 


### PR DESCRIPTION
This simply fix the hdrop Makefile of when running `make install`
To be consistent with the other application Makefiles