### PR TITLE
grimblast: allow customizing slurp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Changelog
 
+### 2024-01-11
+
+Make Grimblast respect the `$SLURP_ARGS` environment variable, which controls
+how `slurp` looks and behaves.
+
+See `slurp -h` or `man slurp` for more information.
+
 ### 2022-02-26
-Added the `edit` option to Grimblast. read the [man page](grimblast/grimblast.1.scd) for more information.
+
+Added the `edit` option to Grimblast. read the
+[man page](grimblast/grimblast.1.scd) for more information.
 
 A rofi script is also included.
 
 ### 2022-02-27
+
 Added Scratchpad Script.

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -217,7 +217,8 @@ elif [ "$SUBJECT" = "area" ]; then
 
   WORKSPACES="$(hyprctl monitors -j | jq -r 'map(.activeWorkspace.id)')"
   WINDOWS="$(hyprctl clients -j | jq -r --argjson workspaces "$WORKSPACES" 'map(select([.workspace.id] | inside($workspaces)))')"
-  GEOM=$(echo "$WINDOWS" | jq -r '.[] | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"' | slurp)
+  # shellcheck disable=2086 # if we don't split, spaces mess up slurp
+  GEOM=$(echo "$WINDOWS" | jq -r '.[] | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"' | slurp $SLURP_ARGS)
 
   # reset fade
   hyprctl keyword animation "$FADE" >/dev/null

--- a/grimblast/grimblast.1.scd
+++ b/grimblast/grimblast.1.scd
@@ -59,23 +59,6 @@ It provides a convenient interface over grim, slurp and jq, and supports
 storing the screenshot either directly to the clipboard using wl-copy or to a
 file.
 
-# EXAMPLES
-
-An example usage pattern is to add these bindings to your hyprland config:
-
-```
-# Screenshots:
-# Super+P: Current window
-# Super+Shift+p: Select area
-# Super+Alt+p Current output
-# Super+Ctrl+p All outputs
-
-bind = SUPER, p, exec, grimblast save active
-bind = SUPER SHIFT, p, exec, grimblast save area
-bind = SUPER ALT, p, exec, grimblast save output
-bind = SUPER CTRL, p, exec, grimblast save screen
-```
-
 # TARGETS
 
 grimblast can capture the following named targets:
@@ -89,6 +72,8 @@ _screen_
 _area_
 	Allows manually selecting a rectangular region or window (by clicking on it),
 	and captures that.
+	Slurp can be customized by setting its arguments in the *SLURP_ARGS*
+	environment variable.
 
 _output_
 	Captures the currently active output.
@@ -98,7 +83,28 @@ _output_
 Grimblast will print the filename of the captured screenshot to stdout if called
 with the _save_ subcommand.
 
+# EXAMPLES
+
+An example usage pattern is to add these bindings to your hyprland config:
+
+```
+# Screenshots:
+# Super+P: Current window
+# Super+Shift+p: Select area
+# Super+Alt+p Current output
+# Super+Ctrl+p All outputs
+
+# Optionally, customize slurp's appearance
+env = SLURP_ARGS, -d -b -B F050F022 -b 10101022 -c ff00ff
+
+bind = SUPER, p, exec, grimblast save active
+bind = SUPER SHIFT, p, exec, grimblast save area
+bind = SUPER ALT, p, exec, grimblast save output
+bind = SUPER CTRL, p, exec, grimblast save screen
+```
+
 # SEE ALSO
 
 *grim*(1)
+*slurp*(1)
 *grimshot*(1)


### PR DESCRIPTION
## Description of changes

`grimblast` now respects `$SLURP_ARGS`, which controls how `slurp` looks and
behaves. See `slurp -h` for options.

Fixes #83.

<!--
For new programs, mention anything describing its usecase, including videos, images and other demos.
-->

## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the
        maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do
        it)
  - [ ] If the program is a script, add it to the
        [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
