### PR TITLE
grimblast: show screenshot on 'copy' notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2024-02-01
+
+Show a screenshot preview on the notification when using `copy` mode and `--notify`
+
 ### 2024-01-11
 
 Make Grimblast respect the `$SLURP_ARGS` environment variable, which controls

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -238,8 +238,8 @@ else
 fi
 
 if [ "$ACTION" = "copy" ]; then
-  takeScreenshot - "$GEOM" "$OUTPUT" | wl-copy --type image/png || die "Clipboard error"
-  notifyOk "$WHAT copied to buffer"
+  takeScreenshot /tmp/grimblast-copy-image "$GEOM" "$OUTPUT" | wl-copy --type image/png || die "Clipboard error"
+  notifyOk "$WHAT copied to buffer" -i /tmp/grimblast-copy-image
 elif [ "$ACTION" = "save" ]; then
   if takeScreenshot "$FILE" "$GEOM" "$OUTPUT"; then
     TITLE="Screenshot of $SUBJECT"


### PR DESCRIPTION
## Description of changes

Save the screenshot to a file in the `/tmp/` folder when using `copy` to show it on the notification.

## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the
        maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do
        it)
  - [ ] If the program is a script, add it to the
        [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
  
![2024-02-01T18:16:37,619419236-06:00](https://github.com/hyprwm/contrib/assets/3086618/0b274ddb-0eb6-4ba2-b058-767660bb14e0)
