### PR TITLE
grimblast: fixed image not going to buffer

### DIFF
--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -238,8 +238,8 @@ else
 fi
 
 if [ "$ACTION" = "copy" ]; then
-  takeScreenshot /tmp/grimblast-copy-image "$GEOM" "$OUTPUT" | wl-copy --type image/png || die "Clipboard error"
-  notifyOk "$WHAT copied to buffer" -i /tmp/grimblast-copy-image
+  takeScreenshot - "$GEOM" "$OUTPUT" | tee "/tmp/grimblast_copy_file" | wl-copy --type image/png || die "Clipboard error"
+  notifyOk "$WHAT copied to buffer" -i "/tmp/grimblast_copy_file"
 elif [ "$ACTION" = "save" ]; then
   if takeScreenshot "$FILE" "$GEOM" "$OUTPUT"; then
     TITLE="Screenshot of $SUBJECT"


### PR DESCRIPTION
## Description of changes

Fixed an issue with my last commit, the screenshot was showing on the notification but it wasn't saved to the buffer, I double checked and this version now works as intended. I'm using the same tactic with `tee` used to show the screenshot when using `copysave`

## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the
        maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do
        it)
  - [ ] If the program is a script, add it to the
        [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [ ] Add changes to the [CHANGELOG](/CHANGELOG.md)
