### PR TITLE
grimblast: include `hyprpicker` to closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2024-04-07
+
+grimblast: add hyprpicker to closure
+
 ### 2024-03-21
 
 grimblast: use fadeLayers to prevent visible borders

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658161305,
-        "narHash": "sha256-X/nhnMCa1Wx4YapsspyAs6QYz6T/85FofrI6NpdPDHg=",
+        "lastModified": 1712163089,
+        "narHash": "sha256-Um+8kTIrC19vD4/lUCN9/cU9kcOsD1O1m+axJqQPyMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e4d49de45a3b5dbcb881656b4e3986e666141ea9",
+        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
         "type": "github"
       },
       "original": {

--- a/grimblast/default.nix
+++ b/grimblast/default.nix
@@ -9,6 +9,7 @@
   libnotify,
   slurp,
   wl-clipboard,
+  hyprpicker,
   hyprland ? null,
 }:
 stdenvNoCC.mkDerivation {
@@ -36,6 +37,7 @@ stdenvNoCC.mkDerivation {
         libnotify
         slurp
         wl-clipboard
+        hyprpicker
       ]
       ++ lib.optional (hyprland != null) hyprland)}"
   '';


### PR DESCRIPTION
## Description of changes

make hyprpicker available to grimblast. I had to update the flake since it wasn't packaged yet on the lock's version.

However, there is a current issue with `nixpkgs`'s hyprpicker: https://github.com/hyprwm/hyprpicker/issues/51 and a workaround is presented in the issue tracker

<!--
For new programs, mention anything describing its usecase, including videos, images and other demos.
-->

## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the
        maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do
        it)
  - [ ] If the program is a script, add it to the
        [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
