### PR TITLE
scratchpad: add gawk to closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2024-04-22
+
+scratchpad: add gawk to closure
+
 ### 2024-04-07
 
 grimblast: add hyprpicker to closure

--- a/scratchpad/default.nix
+++ b/scratchpad/default.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   makeWrapper,
   libnotify,
+  gawk,
   gnused,
   jq,
   procps,
@@ -21,6 +22,7 @@ stdenvNoCC.mkDerivation {
   postInstall = ''
     wrapProgram $out/bin/scratchpad --prefix PATH ':' \
       "${lib.makeBinPath ([
+        gawk
         gnused
         jq
         libnotify


### PR DESCRIPTION
## Description of changes

Ran into an issue where scratchpad couldn't find awk when being ran from KDE Connect.

## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the
        maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do
        it)
  - [ ] If the program is a script, add it to the
        [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
