### PR TITLE
hdrop: fix Nix meta.license value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2024-05-13
+
+hdrop: fix Nix package license
+
 ### 2024-04-22
 
 scratchpad: add gawk to closure

--- a/hdrop/default.nix
+++ b/hdrop/default.nix
@@ -40,7 +40,7 @@ stdenvNoCC.mkDerivation {
     description = "Emulate 'tdrop' in Hyprland (run, show and hide specific programs per keybind)";
     homepage = "https://github.com/Schweber/hdrop";
     changelog = "https://github.com/Schweber/hdrop/releases/tag/v${version}";
-    license = licenses.agpl3;
+    license = licenses.agpl3Only;
     platforms = platforms.linux;
     maintainers = with maintainers; [Schweber];
     mainProgram = "hdrop";


### PR DESCRIPTION
## Description of changes

The `agpl3` license was split into `agpl3Only` and `agpl3Plus` in nixpkgs, and `agpl3` was removed. I've updated it to `agpl3Only`. See NixOS/nixpkgs#297173.

## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the
        maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do
        it)
  - [ ] If the program is a script, add it to the
        [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
