### PR TITLE
grimblast: recognize windows of special workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2024-07-10
+
+grimblast: recognize windows of special workspaces
+
 ### 2024-06-16
 
 shellevents: add README.md

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -220,7 +220,7 @@ elif [ "$SUBJECT" = "area" ]; then
   FADELAYERS="$(hyprctl -j animations | jq -jr '.[0][] | select(.name == "fadeLayers") | .name, ",", (if .enabled == true then "1" else "0" end), ",", (.speed|floor), ",", .bezier')"
   hyprctl keyword animation 'fadeLayers,0,1,default' >/dev/null
 
-  WORKSPACES="$(hyprctl monitors -j | jq -r 'map(.activeWorkspace.id)')"
+  WORKSPACES="$(hyprctl monitors -j | jq -r '[(foreach .[] as $monitor (0; if $monitor.specialWorkspace.name == "" then $monitor.activeWorkspace else $monitor.specialWorkspace end)).id]')"
   WINDOWS="$(hyprctl clients -j | jq -r --argjson workspaces "$WORKSPACES" 'map(select([.workspace.id] | inside($workspaces)))')"
   # shellcheck disable=2086 # if we don't split, spaces mess up slurp
   GEOM=$(echo "$WINDOWS" | jq -r '.[] | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"' | slurp $SLURP_ARGS)


### PR DESCRIPTION
## Description of changes

<!--
For new programs, mention anything describing its usecase, including videos, images and other demos.
-->

Changed the line responsible for getting workspace ids to include special workspaces and ignore the active workspace if a special one is above it. Without it, it was not possible to make a screenshot of a window which is on a special workspace (`grimblast copy area`).

## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the
        maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do
        it)
  - [ ] If the program is a script, add it to the
        [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
