### PR TITLE
grimblast: only allow one instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2024-08-02
+
+grimblast: changed method to check if another instance is running
+
 ### 2024-07-10
 
 grimblast: recognize windows of special workspaces
@@ -26,7 +30,8 @@ grimblast: use fadeLayers to prevent visible borders
 
 ### 2024-03-18
 
-scratchpad: Fixed -m command. Now it kills the preprocess of menu before starting it.
+scratchpad: Fixed -m command. Now it kills the preprocess of menu before
+starting it.
 
 ### 2024-03-13
 
@@ -34,7 +39,7 @@ scratchpad: allow supplying command flags in any order
 
 ### 2024-03-02
 
-hdrop: 0.4.4 -> 0.5.0
+hdrop: 0.4.4 -> 0.5.0\
 Add --floating and associated options
 
 ### 2024-01-25
@@ -43,14 +48,14 @@ grimblast: fixed border still visible when taking screenshot of an area
 
 ### 2024-01-19
 
-hdrop: -> 0.4.4
+hdrop: -> 0.4.4\
 Fix --class quoting
 
 ### 2024-01-14
 
-hdrop: 0.3.0 -> 0.4.0  
-Add `-c | --class`  
-Improve Documentation
+hdrop: 0.3.0 -> 0.4.0\
+Add `-c | --class`\
+Improve Documentation\
 Refactor
 
 ### 2024-01-11

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -18,6 +18,18 @@
 ## hyprctl equivalents.
 ## https://github.com/swaywm/sway/blob/master/contrib/grimshot
 
+# Check whether another instance is running
+
+
+grimblastInstanceCheck="${XDG_RUNTIME_DIR:-$XDG_CACHE_DIR:-$HOME/.cache}/grimblast.lock"
+if [ -e "$grimblastInstanceCheck" ]; then
+	exit 2
+else
+	touch "$grimblastInstanceCheck"
+fi
+trap "rm -f '$grimblastInstanceCheck'" EXIT
+
+
 getTargetDirectory() {
   test -f "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs" &&
     . "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs"

--- a/grimblast/grimblast.1.scd
+++ b/grimblast/grimblast.1.scd
@@ -103,6 +103,11 @@ bind = SUPER ALT, p, exec, grimblast save output
 bind = SUPER CTRL, p, exec, grimblast save screen
 ```
 
+# EXIT CODES
+
+0 - Normal exit++
+2 - Another instance of grimblast is running
+
 # SEE ALSO
 
 *grim*(1)


### PR DESCRIPTION
## Description of changes

<!--
For new programs, mention anything describing its usecase, including videos, images and other demos.
-->

Allow only one instance of grimblast to be active at a time. Fixes #112

## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the
        maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do
        it)
  - [ ] If the program is a script, add it to the
        [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
