### PR TITLE
grimblast: fix window area selection on fullscreen workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2024-12-01
+
+grimblast: fix window selection on fullscreen
+
 ### 2024-11-04
 
 grimblast: use layerrules instead of modifying animations

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -222,8 +222,9 @@ elif [ "$SUBJECT" = "area" ]; then
   # this removes the black border seen around screenshots
   hyprctl keyword layerrule "noanim,selection" >/dev/null
 
+  FULLSCREEN_WORKSPACES="$(hyprctl workspaces -j | jq -r 'map(select(.hasfullscreen) | .id)')"
   WORKSPACES="$(hyprctl monitors -j | jq -r '[(foreach .[] as $monitor (0; if $monitor.specialWorkspace.name == "" then $monitor.activeWorkspace else $monitor.specialWorkspace end)).id]')"
-  WINDOWS="$(hyprctl clients -j | jq -r --argjson workspaces "$WORKSPACES" 'map(select([.workspace.id] | inside($workspaces)))')"
+  WINDOWS="$(hyprctl clients -j | jq -r --argjson workspaces "$WORKSPACES" --argjson fullscreenWorkspaces "$FULLSCREEN_WORKSPACES" 'map((select(([.workspace.id] | inside($workspaces)) and ([.workspace.id] | inside($fullscreenWorkspaces) | not) or .fullscreen > 0)))')"
   # shellcheck disable=2086 # if we don't split, spaces mess up slurp
   GEOM=$(echo "$WINDOWS" | jq -r '.[] | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"' | slurp $SLURP_ARGS)
 


### PR DESCRIPTION
## Description of changes

Fixes window selection on fullscreen windows by filtering only the windows with fullscreen when on fullscreen active workspaces. 

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
