### PR TITLE
grimblast: allow decimals for --wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025-01-24
+
+grimblast: allow decimals for --wait
+
 ### 2024-12-01
 
 grimblast: fix window selection on fullscreen

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -75,7 +75,7 @@ while [ $# -gt 0 ]; do
   -w | --wait)
     shift
     WAIT=$1
-    if echo "$WAIT" | grep "[^0-9]" -q; then
+    if [[ ! "$WAIT" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
       echo "Invalid value for wait '$WAIT'" >&2
       exit 3
     fi

--- a/grimblast/grimblast.1.scd
+++ b/grimblast/grimblast.1.scd
@@ -22,9 +22,10 @@ grimblast - a helper for screenshots within hyprland
 	Freezes the screen before area selection.
 
 *--wait N*
-	Wait for N seconds before taking a screenshot. Waits after any
-	manual selection is made. Recommended to combine with --notify in
-	order to know when the screenshot has been taken.
+	Wait for N seconds before taking a screenshot. Decimal values
+	are also supported. Waits after any manual selection is made.
+	Recommended to combine with --notify in order to know
+	when the screenshot has been taken.
 
 *--scale <scale>*
 	Passes the `-s` argument to `grim`.


### PR DESCRIPTION
## Description of changes

<!--
For new programs, mention anything describing its usecase, including videos, images and other demos.
-->

`grimblast --wait` currently only allows whole numbers, and I myself like to use it to get the cursor out of the way for screenshots, however a whole second is just a bit too unnatural too long for me and I'd like to use something like 0.5 or 0.7, so I've changed the regex to allow adding decimal numbers (I hope the regex is alright)

The usage still says `[--wait N]` but I initally expected `N` to also include decimal numbers, so not sure if this should just stay the same or if the usage should also mention that decimals are allowed, although I think that may be a bit confusing and should just stay this way

## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the
        maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do
        it)
  - [ ] If the program is a script, add it to the
        [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
