### PR TITLE
grimblast: add environment var 'GRIMBLAST_HIDE_CURSOR' to avoid high CPU loads on some machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025-03-03
+
+grimblast: add environment var `GRIMBLAST_HIDE_CURSOR` to avoid high CPU loads on some machines
+
 ### 2025-03-01
 
 grimblast: hide the grim cursor before taking a screenshot

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -209,11 +209,15 @@ takeScreenshot() {
   GEOM=$2
   OUTPUT=$3
   if [ -n "$OUTPUT" ]; then
-    moveCursorPosition && grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} -o "$OUTPUT" "$FILE" && restoreCursorPosition || die "Unable to invoke grim"
+    grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} -o "$OUTPUT" "$FILE" || die "Unable to invoke grim"
   elif [ -z "$GEOM" ]; then
     grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} "$FILE" || die "Unable to invoke grim"
   else
-    moveCursorPosition && grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} -g "$GEOM" "$FILE" && restoreCursorPosition || die "Unable to invoke grim"
+    if [ "$SUBJECT" != "area" ] || [ "$GRIMBLAST_HIDE_CURSOR" = 0 ]; then
+      grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} -g "$GEOM" "$FILE" || die "Unable to invoke grim"
+    else
+      moveCursorPosition && grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} -g "$GEOM" "$FILE" && restoreCursorPosition || die "Unable to invoke grim"
+    fi
   fi
 }
 

--- a/grimblast/grimblast.1.scd
+++ b/grimblast/grimblast.1.scd
@@ -79,6 +79,8 @@ _area_
 	and captures that.
 	Slurp can be customized by setting its arguments in the *SLURP_ARGS*
 	environment variable.
+	If you experience high cpu loads when taking a screenshot with this target,
+	you can set the *GRIMBLAST_HIDE_CURSOR* environment variable to **0**.
 
 _output_
 	Captures the currently active output.
@@ -101,6 +103,9 @@ An example usage pattern is to add these bindings to your hyprland config:
 
 # Optionally, customize slurp's appearance
 env = SLURP_ARGS, -d -b -B F050F022 -b 10101022 -c ff00ff
+
+# Can fix high cpu loads on some machines
+env = GRIMBLAST_HIDE_CURSOR, 0
 
 bind = SUPER, p, exec, grimblast save active
 bind = SUPER SHIFT, p, exec, grimblast save area


### PR DESCRIPTION
## Description of changes

fixes #134

The grim cursor is not visible by default, but if your machine has high CPU loads you can add `env = GRIMBLAST_HIDE_CURSOR, 0` to your Hyprland config file (the grim cursor will be visible).
## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do it)
  - [ ] If the program is a script, add it to the [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [X] Add changes to the [CHANGELOG](/CHANGELOG.md)
  - [X] Reflect your changes in the man pages (if they exist)
