### PR TITLE
Fix erroneous error message when taking screenshots under certain circumstances.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025-03-10
+
+grimblast: Fix erroneous error notification caused by bash syntax error
+
 ### 2025-03-08
 
 grimblast: add check for HYPRLAND_INSANCE_SIGNATURE to avoid confusing errors when the tool is ran in other WMs
@@ -56,9 +60,9 @@ hdrop: add `--focus` option
 
 ### 2024-09-01
 
-hdrop: 
+hdrop:
    - add class replacement for epiphany and godot
-   - refactor 
+   - refactor
    - cleanup
    - add recognition of `--app-id` for foot
    - disable error notifications when closing foot

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -26,7 +26,7 @@ if [ -e "$grimblastInstanceCheck" ]; then
 else
   touch "$grimblastInstanceCheck"
 fi
-trap "rm -f '$grimblastInstanceCheck'" EXIT
+trap 'rm -f "$grimblastInstanceCheck"' EXIT
 
 getTargetDirectory() {
   test -f "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs" &&
@@ -55,7 +55,6 @@ CURSOR=
 FREEZE=
 WAIT=no
 SCALE=
-HYPRPICKER_PID=-1
 
 while [ $# -gt 0 ]; do
   key="$1"
@@ -167,9 +166,9 @@ notifyError() {
 }
 
 killHyprpicker() {
-  if [ ! $HYPRPICKER_PID -eq -1 ]; then
-    kill $HYPRPICKER_PID
-  fi
+   if pidof hyprpicker >/dev/null; then
+      pkill hyprpicker
+   fi
 }
 
 die() {
@@ -209,14 +208,20 @@ takeScreenshot() {
   GEOM=$2
   OUTPUT=$3
   if [ -n "$OUTPUT" ]; then
-    grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} -o "$OUTPUT" "$FILE" || die "Unable to invoke grim"
+    moveCursorPosition
+    if grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} -o "$OUTPUT" "$FILE"; then
+      restoreCursorPosition
+    else
+      die "Unable to invoke grim"
+    fi
   elif [ -z "$GEOM" ]; then
     grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} "$FILE" || die "Unable to invoke grim"
   else
-    if [ "$SUBJECT" != "area" ] || [ "$GRIMBLAST_HIDE_CURSOR" = 0 ]; then
-      grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} -g "$GEOM" "$FILE" || die "Unable to invoke grim"
+    moveCursorPosition
+    if grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} -g "$GEOM" "$FILE"; then
+      restoreCursorPosition
     else
-      moveCursorPosition && grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} -g "$GEOM" "$FILE" && restoreCursorPosition || die "Unable to invoke grim"
+      die "Unable to invoke grim"
     fi
   fi
 }
@@ -264,8 +269,6 @@ elif [ "$SUBJECT" = "area" ]; then
 
   if [ "$FREEZE" = "yes" ] && [ "$(command -v "hyprpicker")" ] >/dev/null 2>&1; then
     hyprpicker -r -z &
-    sleep 0.2
-    HYPRPICKER_PID=$!
   fi
 
   # disable animation for layer namespace "selection" (slurp)


### PR DESCRIPTION
### Goal
This PR fixes https://github.com/hyprwm/contrib/issues/137.

### Changes
- `takeScreenshot() {…}` has been tweaked to use proper `if` statements, fixing a common "A && B || C" problem that made an error notification appear in certain circumstances where there should be none.

- `HYPRPICKER_PID` has been removed thanks to a re-write of `killHyprpicker() {…}` by @DHDcc.

- Currently line 28 is now `trap 'rm -f "$grimblastInstanceCheck"' EXIT`, fixing a simple syntax issue that, whilst not affecting functionality, was still technically wrong.

- If empty spaces at the end of some lines were removed, this was done automatically by my text editor; I guess a little cleaning is still a nice bonus.

- The changelog was updated to add these changes.

### Contributors
- @DHDcc 
- Myself
- @fufexan