### PR TITLE
grimblast: checks if grimblast is running in hyprland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025-03-08
+
+grimblast: add check for HYPRLAND_INSANCE_SIGNATURE to avoid confusing errors when the tool is ran in other WMs
+
 ### 2025-03-03
 
 grimblast: add environment var `GRIMBLAST_HIDE_CURSOR` to avoid high CPU loads on some machines

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -227,6 +227,11 @@ wait() {
   fi
 }
 
+if [ -z "$HYPRLAND_INSTANCE_SIGNATURE" ]; then
+  echo "Error: HYPRLAND_INSTANCE_SIGNATURE not set! (is hyprland running?)"
+  exit 1
+fi
+
 if [ "$ACTION" = "check" ]; then
   echo "Checking if required tools are installed. If something is missing, install it to your system and make it available in PATH..."
   check grim


### PR DESCRIPTION
## Description of changes

Avoids confusions like these https://github.com/hyprwm/contrib/issues/47 by making sure the tool can only run in hyprland (found my own issue while having the same problem but just forgot lmao)
(or i could try making it work in sway but i don't know if the goal is to make these tools for hyprland specifically or not)