### PR TITLE
grimblast: remove `moveCursorPosition` and `restoreCursorPosition` for `OUTPUT` and duplicate `jq` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025-03-15
+
+grimblast: remove moveCursorPosition and restoreCursorPosition for OUTPUT and duplicate jq command
+
 ### 2025-03-10
 
 grimblast: Fix erroneous error notification caused by bash syntax error

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -210,12 +210,7 @@ takeScreenshot() {
   GEOM=$2
   OUTPUT=$3
   if [ -n "$OUTPUT" ]; then
-    moveCursorPosition
-    if grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} -o "$OUTPUT" "$FILE"; then
-      restoreCursorPosition
-    else
-      die "Unable to invoke grim"
-    fi
+    grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} -o "$OUTPUT" "$FILE" || die "Unable to invoke grim"
   elif [ -z "$GEOM" ]; then
     grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} "$FILE" || die "Unable to invoke grim"
   else
@@ -262,7 +257,7 @@ elif [ "$SUBJECT" = "screen" ]; then
 elif [ "$SUBJECT" = "output" ]; then
   wait
   GEOM=""
-  OUTPUT=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true)' | jq -r '.name')
+  OUTPUT=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .name')
   WHAT="$OUTPUT"
 elif [ "$SUBJECT" = "area" ]; then
   if [ "$CURSOR" = "yes" ]; then


### PR DESCRIPTION
## Description of changes

Removed `moveCursorPosition` and `restoreCursorPosition` functions for `OUTPUT` as they are only needed for an area screenshot and removed a duplicate `jq` command to avoid redundancy.

## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do it)
  - [ ] If the program is a script, add it to the [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
  - [x] Reflect your changes in the man pages (if they exist)
