### PR TITLE
grimblast: use `--batch` for `hyprctl` to limit the number of control calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025-03-16
+
+grimblast: use '--batch' for 'hyprctl' to limit the number of control calls
+
 ### 2025-03-15
 
 grimblast: remove moveCursorPosition and restoreCursorPosition for OUTPUT and duplicate jq command

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -194,15 +194,12 @@ moveCursorPosition() {
   virtualDisplayName="grimblastVD"
   focusedMonitorName=$(hyprctl -j monitors | jq -r '.[] | select( .focused == true ) | .name')
 
-  hyprctl output create headless "$virtualDisplayName" >/dev/null
-  hyprctl dispatch focusmonitor "$virtualDisplayName" >/dev/null
+  hyprctl --batch "output create headless $virtualDisplayName; dispatch focusmonitor $virtualDisplayName" >/dev/null
 }
 
 restoreCursorPosition() {
   [ "$GRIMBLAST_HIDE_CURSOR" ] && return 0
-  hyprctl dispatch focusmonitor "$focusedMonitorName" >/dev/null
-  hyprctl output remove "$virtualDisplayName" >/dev/null
-  hyprctl dispatch movecursor "${initialCursorPosition//,/}" >/dev/null
+  hyprctl --batch "dispatch focusmonitor $focusedMonitorName; output remove $virtualDisplayName; dispatch movecursor ${initialCursorPosition//,/}" >/dev/null
 }
 
 takeScreenshot() {


### PR DESCRIPTION
## Description of changes

Use `--batch` for `hyprctl` to limit the number of control calls.

## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do it)
  - [ ] If the program is a script, add it to the [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
  - [x] Reflect your changes in the man pages (if they exist)
