### PR TITLE
grimblast: fix file URI when using --openfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025-05-16
+
+grimblast: fix file URI when using --openfile
+
 ### 2025-05-10
 
 hdrop: 0.7.6 -> 0.7.7\

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -145,7 +145,7 @@ notifyOpen() {
     outt=$(notifyOk -A "default=open_folder" "$@")
     if [ "$outt" == "default" ]; then
       # this does not work for filenames with commas in them
-      if dbus-send --session --print-reply --dest=org.freedesktop.FileManager1 --type=method_call /org/freedesktop/FileManager1 org.freedesktop.FileManager1.ShowItems array:string:"$4" string:""; then
+      if dbus-send --session --print-reply --dest=org.freedesktop.FileManager1 --type=method_call /org/freedesktop/FileManager1 org.freedesktop.FileManager1.ShowItems array:string:"file://$4" string:""; then
         :
       else
         notify-send -t 3000 -a grimblast "Error displaying folder with dbus-send"


### PR DESCRIPTION
## Description of changes

Previously, at least for me, using `--openfile` with `grimblast` would always fail. This fix corrects the file URI used when opening a file from a notification. Refer to the video attached.

https://github.com/user-attachments/assets/f9250d08-b5ec-415d-bef1-048a6ec02e6b

## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do it)
  - [ ] If the program is a script, add it to the [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
  - [ ] Reflect your changes in the man pages (if they exist)
