### PR TITLE
grimblast: remove extra shift on --wait

### DIFF
--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -85,7 +85,6 @@ while [[ $# -gt 0 ]]; do
       echo "Invalid or missing value for --wait" >&2
       exit 3
     fi
-    shift
     ;;
   -s | --scale)
     if [[ -n "${2-}" && "$2" =~ ^[1-9][0-9]*(\.[0-9]+)?$ ]]; then


### PR DESCRIPTION
## Description of changes

<!--
For new programs, mention anything describing its usecase, including videos, images and other demos.
-->

https://github.com/hyprwm/contrib/commit/dafa5d09b413d08a55a81f6f8e85775d717bacda added the `shift 2` but kept the existing trailing `shift`.
## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do it)
  - [ ] If the program is a script, add it to the [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [ ] Add changes to the [CHANGELOG](/CHANGELOG.md)
  - [ ] Reflect your changes in the man pages (if they exist)
