### PR TITLE
grimblast: fix stdout output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025-07-22
+
+grimblast: fix stdout output for the copysave action
+
 ### 2025-07-05
 
 grimblast: nuke cursor repositioning

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -317,9 +317,13 @@ elif [ "$ACTION" = "edit" ]; then
   fi
 else
   if [ "$ACTION" = "copysave" ]; then
-    takeScreenshot - "$GEOM" "$OUTPUT" | tee "$FILE" | wl-copy --type image/png || die "Clipboard error"
+    if [ "$FILE" = "-" ]; then
+        takeScreenshot - "$GEOM" "$OUTPUT" | tee >(wl-copy --type image/png) || die "Clipboard error"
+    else
+        takeScreenshot - "$GEOM" "$OUTPUT" | tee "$FILE" | wl-copy --type image/png || die "Clipboard error"
+        echo "$FILE"
+    fi
     notifyOk "$WHAT copied to buffer and saved to $FILE" -i "$FILE"
-    echo "$FILE"
   else
     notifyError "Error taking screenshot with grim"
   fi


### PR DESCRIPTION
## Description of changes

Fixes the bug described in #162 where when trying to save a file to `-` in the copysave action the program creates a file with that name and doesn't output to the stdout

## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do it)
  - [ ] If the program is a script, add it to the [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
  - [ ] Reflect your changes in the man pages (if they exist)
