### PR TITLE
try_swap_workspace: fix monitor ID after standby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025-08-17
+
+try_swap_workspace: fix get_mon when hyprctl changes order
+
 ### 2025-07-22
 
 grimblast: fix stdout output for the copysave action

--- a/try_swap_workspace/try_swap_workspace
+++ b/try_swap_workspace/try_swap_workspace
@@ -37,7 +37,7 @@ checkUtils() {
 	# shellcheck disable=SC2015
 	check grep && ok "grep" || err "grep"
 	# shellcheck disable=SC2015
-	check grep && ok "cut" || err "cut"
+	check jq && ok "jq" || err "jq"
 	# shellcheck disable=SC2015
 	check notify-send && ok "notify-send (Optional)" || optional "notify-send (Optional)"
 	exit

--- a/try_swap_workspace/try_swap_workspace
+++ b/try_swap_workspace/try_swap_workspace
@@ -97,20 +97,16 @@ getArgs() {
 }
 
 
-#variables
-mon_wrkspcs=()
-
 get_active_mon() {
-  echo $(($(hyprctl monitors | grep 'focused' | grep -n 'yes' | cut -c1)-1))
+  echo $(hyprctl monitors -j | jq '.[] | select(.focused==true) | .id')
 }
 
-get_workspaces_array() {
-  local workspaces
-  workspaces=$(hyprctl monitors | grep 'active workspace' | cut -f3 -d' ')
-  SAVEIFS=$IFS
-  IFS=$'\n'
-  mon_wrkspcs=($workspaces)
-  IFS=$SAVEIFS
+# first argument: workspace to switch to active monitor
+get_currently_active_on_mon() {
+  local target_wrkspc=$1
+  hyprctl monitors -j \
+  | jq --argjson target "$target_wrkspc" \
+  '.[] | select(.activeWorkspace.id==$target) | .id'
 }
 
 # first argument: workspace to switch to
@@ -133,16 +129,9 @@ swap_workspace() {
 switch_or_swap() {
   target_mon=$(get_active_mon)
   target_wrkspc=$1
-  get_workspaces_array
   # check if the workspace is currently displayed on another monitor
-  local currently_active_on_mon=-1
-  for (( i=0; i<${#mon_wrkspcs[@]}; i++ ))
-  do
-    if [[ "$target_wrkspc" == "${mon_wrkspcs[$i]}" ]]; then
-      currently_active_on_mon=$i
-    fi
-  done
-  if [[ $currently_active_on_mon -lt 0 ]]; then
+  currently_active_on_mon=$(get_currently_active_on_mon "$target_wrkspc")
+  if [[ -z $currently_active_on_mon ]]; then
     # workspace is not active on any monitor, do a normal switch
     ok "switching workspace $target_wrkspc to monitor $target_mon"
     switch_workspace "$target_wrkspc" "$target_mon"


### PR DESCRIPTION
## Description of changes

When coming out of standby, the order of `hyprctl monitors` can change. This led try_swap_workspace to target the wrong monitor.
Using the json output ties the ID to the relevant data.

<!--
For new programs, mention anything describing its usecase, including videos, images and other demos.
-->

## Things done

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
  - [x] Reflect your changes in the man pages (if they exist)
