### PR TITLE
fix: --expire-time option description should use tabs not spaces.

### DIFF
--- a/grimblast/grimblast.1.scd
+++ b/grimblast/grimblast.1.scd
@@ -21,7 +21,7 @@ grimblast - a helper for screenshots within hyprland
 
 *--expire-time*
 	Passes this argument to `notify-send` to configure notification expiry.
-    Only works with --notify.
+	Only works with --notify.
 
 *--cursor*
 	Include cursors in the screenshot.


### PR DESCRIPTION
## Description of changes

<!--
For new programs, mention anything describing its usecase, including videos, images and other demos.
-->
When running `scdoc < grimblast.1.scd > grimblast.1`, the following error is emitted: `Error at 24:1: Tabs are required for indentation`. This PR fixes the indentation issue reported by this error.
