### PR TITLE
grimblast: fix incorrect indentation in grimblast.1.scd

### DIFF
--- a/grimblast/grimblast.1.scd
+++ b/grimblast/grimblast.1.scd
@@ -21,7 +21,7 @@ grimblast - a helper for screenshots within hyprland
 
 *--expire-time*
 	Passes this argument to `notify-send` to configure notification expiry.
-    Only works with --notify.
+	Only works with --notify.
 
 *--cursor*
 	Include cursors in the screenshot.


### PR DESCRIPTION
Should use tab as indentation, not spaces.