### PR TITLE
grimblast: update grimshot reference link

### DIFF
--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -16,7 +16,7 @@
 
 ## This tool is based on grimshot, with swaymsg commands replaced by their
 ## hyprctl equivalents.
-## https://github.com/swaywm/sway/blob/master/contrib/grimshot
+## https://github.com/OctopusET/sway-contrib/blob/master/grimshot/grimshot
 
 NAME="$(basename "$0")"
 


### PR DESCRIPTION
Grimshot's repository has moved: https://github.com/swaywm/sway/commit/bb91b7f5fa7fddb582b8dddf208cc335d39da9e7