### PR TITLE
bug: Fix a bug where grimblast would delete the lock file when early exiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### 2025-09-29
 
+grimblast: Fix a bug where grimblast would delete the lock file when early exiting
+
+### 2025-09-29
+
 grimblast: add getopt to Nix wrapper
 grimblast: refactor getopt error handling to avoid duplicate error messages
 

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -33,8 +33,8 @@ cleanup() {
 }
 
 # Entry point
-trap cleanup EXIT
 [[ -e $GRIMBLASTLOCK ]] && exit 2
+trap cleanup EXIT
 touch "$GRIMBLASTLOCK"
 
 [[ $HYPRLAND_INSTANCE_SIGNATURE ]] || {


### PR DESCRIPTION
## Description of changes

The `trap cleanup EXIT` was placed before the `GRIMBLASTLOCK` check, causing the lock file to be deleted on exit. As a result, the program would start again on the next invocation.

## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do it)
  - [ ] If the program is a script, add it to the [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
  - [ ] Reflect your changes in the man pages (if they exist)
