### PR TITLE
test(grimblast): take advantage of $BATS_TEST_DIRNAME. Fixes #182

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025-11-29
+
+grimblast: remove superfluous use of external commands on test setup
+
 ### 2025-09-29
 
 grimblast: Fix a bug where grimblast would delete the lock file when early exiting

--- a/grimblast/test/test.bats
+++ b/grimblast/test/test.bats
@@ -31,7 +31,7 @@
 # set $BATS_LIB_PATH only if not set already, default to /usr/lib/bats
 setup_file() {
     : "${BATS_LIB_PATH:='/usr/lib/bats'}"
-    PATH="$(dirname "$(realpath "$BATS_TEST_FILENAME")")/..:$PATH"
+    PATH="${BATS_TEST_DIRNAME}/..:$PATH"
     bats_require_minimum_version 1.5.0
 }
 


### PR DESCRIPTION
## Description of changes

Improve grimblast test setup by using the $BATS_TEST_DIRNAME variable provided by bats. [Reference](https://bats-core.readthedocs.io/en/stable/writing-tests.html#special-variables)

## Things done

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do it)
  - [ ] If the program is a script, add it to the [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
  - [ ] Reflect your changes in the man pages (if they exist)
