### PR TITLE
cycle-layout: added cycle-layout script

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,7 @@ jobs:
         - try_swap_workspace
         - hdrop
         - hyprosd-mako
+        - cycle-layout
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -18,6 +18,7 @@ jobs:
         - hyprprop/hyprprop
         - try_swap_workspace/try_swap_workspace
         - hdrop/hdrop
+        - cycle-layout/cycle-layout
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2026-03-27
+
+cycle-layout: added cycle-layout script
+
 ### 2026-03-20
 
 grimblast: fix invalid layerrule syntax for area selection

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Community scripts and utilities for Hypr projects
 | [scratchpad](./scratchpad)                 | A Bash script that instantly sends focused window to a special workspace named `scratchpad` and makes it easier to retrieve the window back to the current workspace | @niksingh710          |
 | [hdrop](./hdrop)                           | Run, show and hide programs via keybind. Emulates [tdrop](https://github.com/noctuid/tdrop) in Hyprland                                                              | @Schweber             |
 | [hyprosd-mako](./hyprosd-mako)             | Lightweight Mako-based OSD scripts for volume, brightness, and microphone state                                                 | @KevynValladares21    |
+| [cycle-layout](./cycle-layout)             | Tiny script to cycle layouts for current workspace. | @cebem1nt    |
+
 
 # Installing
 

--- a/cycle-layout/Makefile
+++ b/cycle-layout/Makefile
@@ -1,0 +1,10 @@
+DESTDIR ?= /
+PREFIX ?= $(DESTDIR)usr/local
+EXEC_PREFIX ?= $(PREFIX)
+BINDIR ?= $(EXEC_PREFIX)/bin
+
+install: cycle-layout
+	@install -v -D -m 0755 cycle-layout --target-directory "$(BINDIR)"
+
+uninstall: cycle-layout
+	rm "$(BINDIR)/cycle-layout"

--- a/cycle-layout/README.md
+++ b/cycle-layout/README.md
@@ -1,0 +1,12 @@
+# cycle-layout
+
+Tiny script to cycle layouts (dwindle, scrolling, monocle, master) for current workspace.
+
+## Usage
+
+Run Makefile or simply copy this script where you'd want to, then add this to your hyprland config: 
+
+```ini
+bind = SUPER CTRL, tab, exec, cycle-layout
+```
+

--- a/cycle-layout/cycle-layout
+++ b/cycle-layout/cycle-layout
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+LAYOUTS=(dwindle scrolling monocle master)
+
+INFO=$(hyprctl activeworkspace -j)
+
+LAYOUT=$(printf '%s' "$INFO" | jq -r '.tiledLayout')
+WORKSPACE_ID=$(printf '%s' "$INFO" | jq -r '.id')
+WORKSPACE_NAME=$(printf '%s' "$INFO" | jq -r '.name')
+
+NEXT=-1
+
+for i in "${!LAYOUTS[@]}"; do
+  if [ "${LAYOUTS[i]}" = "$LAYOUT" ]; then
+    NEXT=$(( (i + 1) % ${#LAYOUTS[@]} ))
+    break
+  fi
+done
+
+hyprctl keyword workspace "$WORKSPACE_ID", layout:"${LAYOUTS[$NEXT]}" > /dev/null
+
+notify-send --icon state-information \
+            --app-name $0 \
+            -h "string:x-canonical-private-synchronous:$0" \
+            "Workspace layout was changed" "Layout for workspace $WORKSPACE_NAME: - ${LAYOUTS[$NEXT]}"

--- a/cycle-layout/default.nix
+++ b/cycle-layout/default.nix
@@ -1,0 +1,30 @@
+{
+  hyprland,
+  lib,
+  makeWrapper,
+  stdenvNoCC,
+  withHyprland ? true,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "cycle-layout";
+  version = "0.1.0";
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = lib.optionalString withHyprland ''
+    wrapProgram $out/bin/cycle-layout --prefix PATH ':' "${lib.makeBinPath [hyprland]}"
+  '';
+
+  meta = with lib; {
+    description = "Script to cycle layouts for the current workspace in Hyprland";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    mainProgram = "cycle-layout";
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
     pkgsFor = nixpkgs.legacyPackages;
   in {
     overlays.default = _: prev: {
+      cycle-layout = prev.callPackage ./cycle-layout {hyprland = null;};
       grimblast = prev.callPackage ./grimblast {hyprland = null;};
       hdrop = prev.callPackage ./hdrop {hyprland = null;};
       hyprosd-mako = prev.callPackage ./hyprosd-mako {};


### PR DESCRIPTION
## Description of changes

A small script to cycle per workspace layout. I did not add nix file

### Use case

I use it for my sometimes complicated workflows, it's just nice to dynamically set another layout for a workspace, without need to modify config

## Things done

- For new programs
  - [x] Add the program to the [README](/README.md) table, with yourself as the maintainer
  - [x] Add a README for the program itself
  - [x] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do it)
  - [x] If the program is a script, add it to the [CI checks matrix](/.github/workflows/check.yml)