### PR TITLE
grimblast: support cursor in frozen area capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2026-05-02
+
+grimblast: support cursor in frozen area capture
+
 ### 2026-03-28
 
 cycle-layout: added a flag to set previous layout

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -58,6 +58,7 @@ FILETYPE=png
 
 # These have an effect depending on whether they're set
 #   CURSOR
+#   CAPTURE_CURSOR
 #   FREEZE
 NOTIFY=false
 SHOW_FILE_NOTIFY=false
@@ -122,7 +123,9 @@ get-mime-type() {
 }
 
 freezescreen() {
-    hyprpicker -rz &
+    local args=(-r -z)
+    [[ $CURSOR ]] && args+=(-c)
+    hyprpicker "${args[@]}" &
     sleep 0.2
 }
 
@@ -153,7 +156,7 @@ grimblast::check() {
 # The actual grim command used is printed to stderr
 screenshot() {
     local file="$1" geom="$2" output="$3"
-    xargs --verbose grim <<<"${CURSOR:+-c} ${SCALE:+-s \"$SCALE\"} -t \"$FILETYPE\" ${output:+-o \"$output\"} ${geom:+-g \"$geom\"} \"$file\""
+    xargs --verbose grim <<<"${CAPTURE_CURSOR:+-c} ${SCALE:+-s \"$SCALE\"} -t \"$FILETYPE\" ${output:+-o \"$output\"} ${geom:+-g \"$geom\"} \"$file\""
 }
 
 # Special actions: usage and check. These are special because they allow to exit early
@@ -215,10 +218,12 @@ output() {
 
 area() {
     local fullscreen_workspaces workspaces windows
-    [[ $CURSOR ]] && die "'-c|--cursor' cannot be used with TARGET 'area'"
+    [[ $CURSOR && ! $FREEZE ]] && die "'-c|--cursor' can only be used with TARGET 'area' when '-f|--freeze' is also set"
 
-    if [[ $FREEZE ]] && grimblast::check -q hyprpicker; then
+    if [[ $FREEZE ]]; then
+        grimblast::check -q hyprpicker || die "'-f|--freeze' requires hyprpicker"
         freezescreen
+        CAPTURE_CURSOR=
     fi
 
     # disable animation for layer namespace "selection" (slurp)
@@ -347,6 +352,7 @@ main() {
                 ;;
             -c | --cursor)
                 CURSOR=1
+                CAPTURE_CURSOR=1
                 shift
                 ;;
             -f | --freeze)

--- a/grimblast/grimblast
+++ b/grimblast/grimblast
@@ -58,7 +58,6 @@ FILETYPE=png
 
 # These have an effect depending on whether they're set
 #   CURSOR
-#   CAPTURE_CURSOR
 #   FREEZE
 NOTIFY=false
 SHOW_FILE_NOTIFY=false
@@ -124,9 +123,13 @@ get-mime-type() {
 
 freezescreen() {
     local args=(-r -z)
-    [[ $CURSOR ]] && args+=(-c)
+    [[ $CURSOR ]] && hyprpicker-supports-cursor && args+=(-c)
     hyprpicker "${args[@]}" &
     sleep 0.2
+}
+
+hyprpicker-supports-cursor() {
+    hyprpicker --help 2>&1 | grep -q -- '--cursor'
 }
 
 # Checks whether an individual tool is available
@@ -156,7 +159,7 @@ grimblast::check() {
 # The actual grim command used is printed to stderr
 screenshot() {
     local file="$1" geom="$2" output="$3"
-    xargs --verbose grim <<<"${CAPTURE_CURSOR:+-c} ${SCALE:+-s \"$SCALE\"} -t \"$FILETYPE\" ${output:+-o \"$output\"} ${geom:+-g \"$geom\"} \"$file\""
+    xargs --verbose grim <<<"${CURSOR:+-c} ${SCALE:+-s \"$SCALE\"} -t \"$FILETYPE\" ${output:+-o \"$output\"} ${geom:+-g \"$geom\"} \"$file\""
 }
 
 # Special actions: usage and check. These are special because they allow to exit early
@@ -222,8 +225,9 @@ area() {
 
     if [[ $FREEZE ]]; then
         grimblast::check -q hyprpicker || die "'-f|--freeze' requires hyprpicker"
+        [[ ! $CURSOR ]] || hyprpicker-supports-cursor || die "'-c|--cursor' with TARGET 'area' and '-f|--freeze' requires a hyprpicker version with --cursor support"
         freezescreen
-        CAPTURE_CURSOR=
+        CURSOR=
     fi
 
     # disable animation for layer namespace "selection" (slurp)
@@ -352,7 +356,6 @@ main() {
                 ;;
             -c | --cursor)
                 CURSOR=1
-                CAPTURE_CURSOR=1
                 shift
                 ;;
             -f | --freeze)

--- a/grimblast/grimblast.1.scd
+++ b/grimblast/grimblast.1.scd
@@ -24,7 +24,9 @@ grimblast - a helper for screenshots within Hyprland
 	Only works with --notify. Default: 3000.
 
 *-c, --cursor*
-	Include cursors in the screenshot.
+	Include cursors in the screenshot. With the _area_ target, this option
+	requires *--freeze* so the cursor is included in the frozen preview and
+	not captured again at the final selection position.
 
 *-f, --freeze*
 	Freezes the screen before area selection.

--- a/grimblast/grimblast.1.scd
+++ b/grimblast/grimblast.1.scd
@@ -26,7 +26,8 @@ grimblast - a helper for screenshots within Hyprland
 *-c, --cursor*
 	Include cursors in the screenshot. With the _area_ target, this option
 	requires *--freeze* so the cursor is included in the frozen preview and
-	not captured again at the final selection position.
+	not captured again at the final selection position. This also requires a
+	hyprpicker version with *--cursor* support.
 
 *-f, --freeze*
 	Freezes the screen before area selection.

--- a/grimblast/test/test.bats
+++ b/grimblast/test/test.bats
@@ -143,6 +143,22 @@ teardown() {
 }
 
 # bats test_tags=arguments
+@test "Can screenshot area with freeze and cursor" {
+    DEFAULT_TARGET_DIR="$TEST_DIR" run --separate-stderr grimblast save area --freeze --cursor
+    assert_success
+    outfile="$(extract_outfile_from_output "$output")"
+    assert_file_exist "$outfile"
+    pngcheck -q "$outfile"
+}
+
+# bats test_tags=arguments
+@test "Rejects cursor for area without freeze" {
+    run grimblast --cursor save area
+    assert_failure
+    assert_output --partial "can only be used with TARGET 'area' when '-f|--freeze' is also set"
+}
+
+# bats test_tags=arguments
 @test "Can screenshot area, to a file, with freeze and notify at the end" {
     run --separate-stderr grimblast save area "$TEST_DIR/test.png" --notify --freeze
     assert_success


### PR DESCRIPTION
## Description of changes

Allow `grimblast --freeze --cursor ... area` now that hyprpicker can include the cursor in its frozen screencopy.

Fixes #92 (with the caveat that it only works with hardware cursors, software cursors still borked).
Depends on hyprwm/hyprpicker#156.

- For new programs
  - [ ] Add the program to the [README](/README.md) table, with yourself as the maintainer
  - [ ] Add a README for the program itself
  - [ ] Add Makefile (and Nix derivation optionally, otherwise @fufexan will do it)
  - [ ] If the program is a script, add it to the [CI checks matrix](/.github/workflows/check.yml)

- For changes
  - [x] Add changes to the [CHANGELOG](/CHANGELOG.md)
  - [x] Reflect your changes in the man pages (if they exist)

## Example: (notice there's no double cursor)

<img width="678" height="93" alt="image" src="https://github.com/user-attachments/assets/9a573cca-3d14-4d4c-9c15-21d96761472b" />